### PR TITLE
[Enhancement] Added cache lock for project entries deletion in bulk @coderabbitai

### DIFF
--- a/app/DTO/ProjectRoleDTO.php
+++ b/app/DTO/ProjectRoleDTO.php
@@ -59,11 +59,11 @@ class ProjectRoleDTO
     }
 
     /**
-     * Only creator and manager can delete all the entries at once
+     * Only the creator delete all the entries at once
      */
     public function canDeleteEntries(): bool
     {
-        return $this->isCreator() || $this->isManager();
+        return $this->isCreator();
     }
 
     public function canDeleteEntry($entry): bool

--- a/app/Http/Controllers/Web/Project/ProjectDeleteEntriesController.php
+++ b/app/Http/Controllers/Web/Project/ProjectDeleteEntriesController.php
@@ -2,6 +2,7 @@
 
 namespace ec5\Http\Controllers\Web\Project;
 
+use Cache;
 use ec5\Models\Project\ProjectStats;
 use ec5\Traits\Eloquent\Archiver;
 use ec5\Traits\Eloquent\StatsRefresher;
@@ -27,6 +28,11 @@ class ProjectDeleteEntriesController
         if ($this->requestedProject()->status !== config('epicollect.strings.project_status.locked')) {
             return view('errors.gen_error')->withErrors(['errors' => ['ec5_91']]);
         }
+        //check lock for this user (only 1 deletion process per user)
+        $userId = $this->requestedUser()->id;
+        $userCacheKey = 'bulk_entries_deletion_user_' . $userId;
+        // Remove the user-level cache lock if it exists (optional, only if you want to reset the lock here)
+        Cache::lock($userCacheKey)->release();
 
         //refresh stats to get the latest entries and branch entries counts
         $this->refreshProjectStats($this->requestedProject());

--- a/config/cache.php
+++ b/config/cache.php
@@ -45,6 +45,7 @@ return [
         'file' => [
             'driver' => 'file',
             'path' => storage_path('framework/cache/data'),
+            'events' => false//to increase performance?
         ],
 
         'memcached' => [

--- a/resources/views/project/manage_entries/deletion_tab_panel.blade.php
+++ b/resources/views/project/manage_entries/deletion_tab_panel.blade.php
@@ -9,11 +9,22 @@
                         &nbsp;More info.
                     </a>
                 </div>
+
+            </div>
+
+        @elseif($requestAttributes->requestedProjectRole->getRole() !== config('epicollect.strings.project_roles.creator'))
+            <div class="panel-body">
+                <div class="warning-well">
+                    You do not have the permissions to delete all the entries in bulk
+                    <a href="https://docs.epicollect.net/web-application/manage-entries/entries-bulk-deletion"
+                       target="_blank">
+                        &nbsp;More info.
+                    </a>
+                </div>
             </div>
         @else
             <div class="panel-body">
                 <span>{{ trans('site.entries_deletion_description') }}</span>
-
                 <div class="pull-right">
                     @if (
                         $requestAttributes->requestedProjectRole->getUser()->isSuperAdmin() ||

--- a/tests/Http/Controllers/Web/Project/ProjectDeleteEntriesControllerTest.php
+++ b/tests/Http/Controllers/Web/Project/ProjectDeleteEntriesControllerTest.php
@@ -197,13 +197,21 @@ class ProjectDeleteEntriesControllerTest extends TestCase
         $response = $this->actingAs($manager, self::DRIVER)
             ->get('myprojects/' . $project->slug . '/delete-entries');
 
-        $this->assertEquals('project.project_delete_entries', $response->original->getName());
-        // Assert the view has the correct variables
-        $response->assertViewHas('project');
-        $projectDTOInstance = $response->original->getData()['project'];
-        // Assert that the 'project' variable is an instance of ProjectDTO
-        $this->assertInstanceOf(ProjectDTO::class, $projectDTOInstance);
-        $response->assertViewHas('totalEntries', $projectStats->total_entries);
+        //fails as manager role cannot delete entries in bulk
+        $this->assertEquals('errors.gen_error', $response->original->getName());
+        // Assert that there is an error message with key 'ec5_91'
+        $this->assertArrayHasKey('errors', $response->original->getData());
+        // Assert that the view has an 'errors' variable
+        $this->assertTrue($response->original->offsetExists('errors'));
+        // Access the MessageBag and assert specific errors
+        $errors = $response->original->offsetGet('errors');
+        // Ensure that the 'errors' key exists in the MessageBag
+        $this->assertTrue($errors->has('errors'));
+        // Access the 'errors' array directly
+        $errorsArray = $errors->get('errors');
+        // Assert that it is an array and contains 'ec5_91'
+        $this->assertIsArray($errorsArray);
+        $this->assertEquals('ec5_91', $errorsArray[0]);
     }
 
     public function test_delete_entries_page_but_role_is_curator()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated deletion operations so that only content creators can remove entries and projects.
  - Introduced a locking mechanism to prevent simultaneous deletion actions with clear error messages when conflicts occur.
  - Enhanced the user interface with explicit warnings for users lacking proper deletion permissions.

- **Chores**
  - Optimized caching settings to improve overall application performance.

- **Tests**
  - Expanded automated tests to verify proper handling of concurrent deletions and role-based access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->