### PR TITLE
Add GitHub Actions workflow to automate release notes from CHANGELOG.md

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -11,8 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-
+        uses: actions/checkout@v4
       - name: Extract release notes from CHANGELOG.md
         id: changelog
         run: |

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -3,7 +3,7 @@ name: Generate Release Notes
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+' # Triggers the workflow when a tag matching the version pattern is pushed (e.g., 11.1.1)
+      - '[0-9]*.[0-9]*.[0-9]*' # Triggers the workflow when a tag matching the version pattern is pushed (e.g., 11.1.1)
 
 jobs:
   generate-release-notes:
@@ -30,7 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: Release ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.release_notes }}
           draft: false
           prerelease: false

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,37 @@
+name: Generate Release Notes
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+' # Triggers the workflow when a tag matching the version pattern is pushed (e.g., 11.1.1)
+
+jobs:
+  generate-release-notes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Extract release notes from CHANGELOG.md
+        id: changelog
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/} # Extract the tag (e.g., 11.1.1)
+          echo "Extracting release notes for version: $TAG_VERSION"
+          RELEASE_NOTES=$(awk -v version="$TAG_VERSION" '
+            $0 ~ "# " version {flag=1; next}
+            $0 ~ "# " && flag {exit}
+            flag {print}
+          ' CHANGELOG.md)
+          echo "::set-output name=release_notes::$RELEASE_NOTES"
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: ${{ steps.changelog.outputs.release_notes }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -23,7 +23,7 @@ jobs:
             $0 ~ "# " && flag {exit}
             flag {print}
           ' CHANGELOG.md)
-          echo "::set-output name=release_notes::$RELEASE_NOTES"
+          echo "release_notes=$RELEASE_NOTES" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         uses: actions/create-release@v1


### PR DESCRIPTION
This commit adds a GitHub Actions workflow that automatically generates release notes from the CHANGELOG.md file whenever a new version tag (e.g., 11.1.1) is pushed.

The workflow:
1. Triggers on tag pushes matching the pattern {version}.{major}.{minor}.
2. Extracts release notes for the specific version from CHANGELOG.md.
3. Creates a GitHub release with the extracted notes.

This automation ensures consistent and accurate release notes for every versioned release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an automated workflow that generates release notes and publishes releases when new version tags are pushed.
  - This update streamlines the release process by ensuring each version update is accompanied by clear, up-to-date release information, reducing manual effort and improving reliability for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->