### PR TITLE
Added a lower throttle limit for oauth token endpoint

### DIFF
--- a/app/Providers/RateLimiterServiceProvider.php
+++ b/app/Providers/RateLimiterServiceProvider.php
@@ -34,6 +34,7 @@ class RateLimiterServiceProvider extends ServiceProvider
         $this->configureAccountDeletionLimiter();
         $this->configurePasswordlessLimiter();
         $this->configureApiExportLimiters();
+        $this->configureOauthTokenLimiter();
     }
 
     /**
@@ -82,6 +83,17 @@ class RateLimiterServiceProvider extends ServiceProvider
             return Limit::perMinute(
                 config("epicollect.limits.api_export.$configKey")
             )->by($request->ip());
+        });
+    }
+
+    /**
+     * Configure rate limiter for the /api/oauth/token endpoint.
+     */
+    private function configureOauthTokenLimiter(): void
+    {
+        RateLimiter::for('oauth-token', function (Request $request) {
+            return Limit::perHour(config('epicollect.limits.oauth_token_limit'))
+                ->by($request->ip());
         });
     }
 }

--- a/config/epicollect/limits.php
+++ b/config/epicollect/limits.php
@@ -86,6 +86,7 @@ return [
     //per hour limit
     'passwordless_rate_limit' => (int) env('PASSWORDLESS_RATE_LIMIT', 10),
     'account_deletion_limit' => (int) env('ACCOUNT_DELETION_LIMIT', 1),
+    'oauth_token_limit' => (int) env('OAUTH_TOKEN_LIMIT', 10),
     //per minute limit
     'api_export' => [
         'project' => (int) env('API_RATE_LIMIT_PROJECT', 60),

--- a/routes/api_external.php
+++ b/routes/api_external.php
@@ -120,11 +120,6 @@ Route::group(['middleware' => ['throttle:600,1']], function () {
 
 // Throttle documented entries READ endpoints - 60 requests per minute
 Route::group(['middleware' => ['throttle:api-export-entries']], function () {
-
-    /* Routes used specifically for OAuth 2 client requests */
-    // Issue client access_token
-    Route::post('api/oauth/token', 'Api\OAuth\OAuthController@issueToken');
-
     /* Export endpoints */
     // Set project permissions api middleware
     Route::group(['middleware' => ['project.permissions.api']], function () {
@@ -132,6 +127,14 @@ Route::group(['middleware' => ['throttle:api-export-entries']], function () {
         Route::get('api/export/entries/{project_slug}', 'Api\Entries\View\ViewEntriesDataController@export');
     });
 });
+
+// Throttle oauth token endpoint - 10 requests per hour by default
+Route::group(['middleware' => ['throttle:oauth-token']], function () {
+    /* Routes used specifically for OAuth 2 client requests */
+    // Issue client access_token
+    Route::post('api/oauth/token', 'Api\OAuth\OAuthController@issueToken');
+});
+
 
 // Throttle documented project READ endpoints - 60 requests per minute
 Route::group(['middleware' => ['throttle:api-export-project']], function () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a dedicated rate limit for OAuth token requests, with a default limit of 10 requests per hour per IP address.
- **Chores**
	- Updated configuration options to allow customization of the OAuth token rate limit via environment variables.
	- Adjusted routing to apply the new rate limit specifically to OAuth token endpoints, ensuring stricter control over token issuance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->