### PR TITLE
Added retries for S3 uploads

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,20 @@
+# CodeRabbit configuration file
+# https://docs.coderabbit.ai/guides/review-guide
+
+reviews:
+  # Disable PHPMD (PHP Mess Detector) checks
+  tools:
+    phpmd:
+      enabled: false
+  
+  # Optional: Configure other review settings
+  auto_review:
+    enabled: true
+    drafts: false
+  
+  # Optional: Configure which files to review
+  path_filters:
+    - "!vendor/**"
+    - "!node_modules/**"
+    - "!storage/**"
+    - "!bootstrap/cache/**"

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -6,12 +6,12 @@ reviews:
   tools:
     phpmd:
       enabled: false
-  
+
   # Optional: Configure other review settings
   auto_review:
     enabled: true
     drafts: false
-  
+
   # Optional: Configure which files to review
   path_filters:
     - "!vendor/**"

--- a/app/Services/Media/AudioVideoSaverService.php
+++ b/app/Services/Media/AudioVideoSaverService.php
@@ -62,7 +62,10 @@ class AudioVideoSaverService
                             'visibility' => 'public',
                             'directory_visibility' => 'public'
                         ]);
-                        break; // Success, exit retry loop
+                        if ($fileSaved) {
+                            break; // Success, exit retry loop
+                        }
+
                     } catch (Throwable $e) {
                         if ($retry === $maxRetries || !($e instanceof S3Exception && Common::isRetryableError($e))) {
                             fclose($stream);

--- a/app/Services/Project/ProjectAvatarService.php
+++ b/app/Services/Project/ProjectAvatarService.php
@@ -133,7 +133,7 @@ class ProjectAvatarService
                 ->setFontSize($this->fontSize['thumb'])
                 ->getImageObject();
 
-            $imageThumbEncoded = $imageThumb->encode(new JpegEncoder(75));
+            $imageThumbEncoded = $imageThumb->encode(new JpegEncoder($this->quality));
 
             // Then upload using Storage::put() with retries
             $maxRetries = 3;

--- a/tests/Services/Media/AudioVideoSaverServiceS3Test.php
+++ b/tests/Services/Media/AudioVideoSaverServiceS3Test.php
@@ -40,12 +40,18 @@ class AudioVideoSaverServiceS3Test extends TestCase
         $disk = 'audio';
         $file = ['path' => 'temp/'.$fileName];
 
-        // Mock S3 read stream
+        // Mock S3 read stream with fixture data
         Storage::shouldReceive('disk')
             ->with('s3')
+            ->once()
             ->andReturnSelf();
+
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, 'fake audio content');
+        rewind($stream);
         Storage::shouldReceive('readStream')
-            ->andReturn(fopen('php://memory', 'r'));
+            ->once() // Explicit expectation: stream should be read only once
+            ->andReturn($stream);
 
         // Mock target disk to throw S3Exception with 429
         Storage::shouldReceive('disk')
@@ -59,7 +65,6 @@ class AudioVideoSaverServiceS3Test extends TestCase
                 ['response' => new Response(429)]
             ));
 
-        // Assert service returns false when S3 errors occur
         $result = AudioVideoSaverService::saveFile($projectRef, $file, $fileName, $disk, true);
         $this->assertFalse($result);
     }
@@ -72,14 +77,20 @@ class AudioVideoSaverServiceS3Test extends TestCase
         $projectRef = Generators::projectRef();
         $fileName = Uuid::uuid4()->toString(). '_' . time() . '.mp4';
         $disk = 'video';
-        $file = ['path' => 'temp/.'.$fileName];
+        $file = ['path' => 'temp/'.$fileName];
 
-        // Mock S3 read stream
+        // Mock S3 read stream with fixture data
         Storage::shouldReceive('disk')
             ->with('s3')
+            ->once()
             ->andReturnSelf();
+
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, 'fake video content');
+        rewind($stream);
         Storage::shouldReceive('readStream')
-            ->andReturn(fopen('php://memory', 'r'));
+            ->once() // Explicit expectation: stream should be read only once
+            ->andReturn($stream);
 
         // Mock target disk to throw S3Exception with 503
         Storage::shouldReceive('disk')
@@ -107,14 +118,18 @@ class AudioVideoSaverServiceS3Test extends TestCase
         $disk = 'audio';
         $file = ['path' => 'temp/'.$fileName];
 
-        // Mock S3 read stream
+        // Mock S3 read stream with fixture data
         Storage::shouldReceive('disk')
             ->with('s3')
             ->once()
             ->andReturnSelf();
+
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, 'fake audio content for success test');
+        rewind($stream);
         Storage::shouldReceive('readStream')
-            ->once()
-            ->andReturn(fopen('php://memory', 'r'));
+            ->once() // Explicit expectation: stream should be read only once
+            ->andReturn($stream);
 
         // Mock target disk for successful save
         Storage::shouldReceive('disk')
@@ -128,5 +143,46 @@ class AudioVideoSaverServiceS3Test extends TestCase
         // Assert service returns true on successful save
         $result = AudioVideoSaverService::saveFile($projectRef, $file, $fileName, $disk, true);
         $this->assertTrue($result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_service_handles_s3_403_forbidden_error_without_retry()
+    {
+        $projectRef = 'test-project-ref';
+        $fileName = 'test-audio.mp3';
+        $disk = 'audio';
+        $file = ['path' => 'temp/test-audio.mp3'];
+
+        // Mock S3 read stream with fixture data
+        Storage::shouldReceive('disk')
+            ->with('s3')
+            ->once()
+            ->andReturnSelf();
+
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, 'fake audio content for 403 test');
+        rewind($stream);
+        Storage::shouldReceive('readStream')
+            ->once() // Explicit expectation: stream should be read only once
+            ->andReturn($stream);
+
+        // Mock target disk to throw non-retryable S3Exception with 403
+        Storage::shouldReceive('disk')
+            ->with($disk)
+            ->once()
+            ->andReturnSelf();
+        Storage::shouldReceive('put')
+            ->once() // Expect only 1 call (no retries for 403)
+            ->andThrow(new S3Exception(
+                'Forbidden',
+                new Command('PutObject'),
+                ['response' => new Response(403)]
+            ));
+
+        // Assert service returns false when non-retryable S3 error occurs
+        $result = AudioVideoSaverService::saveFile($projectRef, $file, $fileName, $disk, true);
+        $this->assertFalse($result);
     }
 }

--- a/tests/Services/Media/AudioVideoSaverServiceS3Test.php
+++ b/tests/Services/Media/AudioVideoSaverServiceS3Test.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tests\Services\Media;
+
+use ec5\Libraries\Utilities\Generators;
+use ec5\Services\Media\AudioVideoSaverService;
+use Exception;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Ramsey\Uuid\Uuid;
+use Tests\TestCase;
+use Mockery;
+use Storage;
+use Aws\S3\Exception\S3Exception;
+use Aws\Command;
+use GuzzleHttp\Psr7\Response;
+
+class AudioVideoSaverServiceS3Test extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->overrideStorageDriver('s3');
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_service_handles_s3_429_too_many_requests_error()
+    {
+        $projectRef = Generators::projectRef();
+        $fileName = Uuid::uuid4()->toString(). '_' . time() . '.mp4';
+        $disk = 'audio';
+        $file = ['path' => 'temp/'.$fileName];
+
+        // Mock S3 read stream
+        Storage::shouldReceive('disk')
+            ->with('s3')
+            ->andReturnSelf();
+        Storage::shouldReceive('readStream')
+            ->andReturn(fopen('php://memory', 'r'));
+
+        // Mock target disk to throw S3Exception with 429
+        Storage::shouldReceive('disk')
+            ->with($disk)
+            ->andReturnSelf();
+        Storage::shouldReceive('put')
+            ->times(4) // Expect 4 calls (1 initial + 3 retries)
+            ->andThrow(new S3Exception(
+                'Too Many Requests',
+                new Command('PutObject'),
+                ['response' => new Response(429)]
+            ));
+
+        // Assert service returns false when S3 errors occur
+        $result = AudioVideoSaverService::saveFile($projectRef, $file, $fileName, $disk, true);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_service_handles_s3_503_service_unavailable_error()
+    {
+        $projectRef = Generators::projectRef();
+        $fileName = Uuid::uuid4()->toString(). '_' . time() . '.mp4';
+        $disk = 'video';
+        $file = ['path' => 'temp/.'.$fileName];
+
+        // Mock S3 read stream
+        Storage::shouldReceive('disk')
+            ->with('s3')
+            ->andReturnSelf();
+        Storage::shouldReceive('readStream')
+            ->andReturn(fopen('php://memory', 'r'));
+
+        // Mock target disk to throw S3Exception with 503
+        Storage::shouldReceive('disk')
+            ->with($disk)
+            ->andReturnSelf();
+        Storage::shouldReceive('put')
+            ->times(4) // Expect 4 calls (1 initial + 3 retries)
+            ->andThrow(new S3Exception(
+                'Service Unavailable',
+                new Command('PutObject'),
+                ['response' => new Response(503)]
+            ));
+
+        $result = AudioVideoSaverService::saveFile($projectRef, $file, $fileName, $disk, true);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_service_successfully_saves_file_to_s3()
+    {
+        $projectRef = Generators::projectRef();
+        $fileName = Uuid::uuid4()->toString(). '_' . time() . '.mp4';
+        $disk = 'audio';
+        $file = ['path' => 'temp/'.$fileName];
+
+        // Mock S3 read stream
+        Storage::shouldReceive('disk')
+            ->with('s3')
+            ->once()
+            ->andReturnSelf();
+        Storage::shouldReceive('readStream')
+            ->once()
+            ->andReturn(fopen('php://memory', 'r'));
+
+        // Mock target disk for successful save
+        Storage::shouldReceive('disk')
+            ->with($disk)
+            ->once()
+            ->andReturnSelf();
+        Storage::shouldReceive('put')
+            ->once()
+            ->andReturn(true);
+
+        // Assert service returns true on successful save
+        $result = AudioVideoSaverService::saveFile($projectRef, $file, $fileName, $disk, true);
+        $this->assertTrue($result);
+    }
+}

--- a/tests/Services/Media/AudioVideoSaverServiceS3Test.php
+++ b/tests/Services/Media/AudioVideoSaverServiceS3Test.php
@@ -8,26 +8,21 @@ use Exception;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Ramsey\Uuid\Uuid;
 use Tests\TestCase;
-use Mockery;
 use Storage;
 use Aws\S3\Exception\S3Exception;
 use Aws\Command;
 use GuzzleHttp\Psr7\Response;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
 class AudioVideoSaverServiceS3Test extends TestCase
 {
     use DatabaseTransactions;
+    use MockeryPHPUnitIntegration;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->overrideStorageDriver('s3');
-    }
-
-    protected function tearDown(): void
-    {
-        Mockery::close();
-        parent::tearDown();
     }
 
     /**

--- a/tests/Services/Media/AudioVideoSaverServiceS3Test.php
+++ b/tests/Services/Media/AudioVideoSaverServiceS3Test.php
@@ -25,9 +25,6 @@ class AudioVideoSaverServiceS3Test extends TestCase
         $this->overrideStorageDriver('s3');
     }
 
-    /**
-     * @throws Exception
-     */
     public function test_service_handles_s3_429_too_many_requests_error()
     {
         $projectRef = Generators::projectRef();

--- a/tests/Services/Media/PhotoSaverServiceS3Test.php
+++ b/tests/Services/Media/PhotoSaverServiceS3Test.php
@@ -6,6 +6,7 @@ use ec5\Libraries\Utilities\Generators;
 use ec5\Services\Media\PhotoSaverService;
 use Exception;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Ramsey\Uuid\Uuid;
 use Tests\TestCase;
 use Mockery;
@@ -18,17 +19,12 @@ use Illuminate\Http\Testing\File;
 class PhotoSaverServiceS3Test extends TestCase
 {
     use DatabaseTransactions;
+    use MockeryPHPUnitIntegration;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->overrideStorageDriver('s3');
-    }
-
-    protected function tearDown(): void
-    {
-        Mockery::close();
-        parent::tearDown();
     }
 
     /**

--- a/tests/Services/Media/PhotoSaverServiceS3Test.php
+++ b/tests/Services/Media/PhotoSaverServiceS3Test.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Services\Media;
+
+use ec5\Libraries\Utilities\Generators;
+use ec5\Services\Media\PhotoSaverService;
+use Exception;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Ramsey\Uuid\Uuid;
+use Tests\TestCase;
+use Mockery;
+use Storage;
+use Aws\S3\Exception\S3Exception;
+use Aws\Command;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Http\Testing\File;
+
+class PhotoSaverServiceS3Test extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->overrideStorageDriver('s3');
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_service_handles_s3_429_too_many_requests_error()
+    {
+        $projectRef = Generators::projectRef();
+        $fileName = Uuid::uuid4()->toString(). '_' . time() . '.jpg';
+        $disk = 'entry_original';
+
+        // Create a fake uploaded file
+        $uploadedFile = File::fake()->image($fileName, 1024, 768);
+
+        // Mock Storage facade - need to mock the actual disk calls
+        Storage::shouldReceive('disk')
+            ->with($disk)
+            ->times(4) // Called 4 times (1 initial + 3 retries)
+            ->andReturnSelf();
+
+        Storage::shouldReceive('put')
+            ->with($projectRef . '/' . $fileName, Mockery::any())
+            ->times(4) // Expect 4 calls (1 initial + 3 retries)
+            ->andThrow(new S3Exception(
+                'Too Many Requests',
+                new Command('PutObject'),
+                ['response' => new Response(429)]
+            ));
+
+        // Assert service returns false when S3 errors occur
+        $result = PhotoSaverService::saveImage($projectRef, $uploadedFile, $fileName, $disk);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_service_handles_s3_503_service_unavailable_error()
+    {
+        $projectRef = Generators::projectRef();
+        $fileName = Uuid::uuid4()->toString(). '_' . time() . '.jpg';
+        $disk = 'entry_original';
+
+        // Create a fake uploaded file
+        $uploadedFile = File::fake()->image($fileName, 1024, 768);
+
+        // Mock Storage facade - need to mock the actual disk calls
+        Storage::shouldReceive('disk')
+            ->with($disk)
+            ->times(4) // Called 4 times (1 initial + 3 retries)
+            ->andReturnSelf();
+
+        Storage::shouldReceive('put')
+            ->with($projectRef . '/' . $fileName, Mockery::any())
+            ->times(4) // Expect 4 calls (1 initial + 3 retries)
+            ->andThrow(new S3Exception(
+                'Service Unavailable',
+                new Command('PutObject'),
+                ['response' => new Response(503)]
+            ));
+
+        $result = PhotoSaverService::saveImage($projectRef, $uploadedFile, $fileName, $disk);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_service_successfully_saves_image_to_s3()
+    {
+        $projectRef = Generators::projectRef();
+        $fileName = Uuid::uuid4()->toString(). '_' . time() . '.jpg';
+        $disk = 'entry_original';
+
+        // Create a fake uploaded file
+        $uploadedFile = File::fake()->image($fileName, 1024, 768);
+
+        // Mock Storage facade for successful save
+        Storage::shouldReceive('disk')
+            ->with($disk)
+            ->once()
+            ->andReturnSelf();
+
+        Storage::shouldReceive('put')
+            ->with($projectRef . '/' . $fileName, Mockery::any())
+            ->once()
+            ->andReturn(true);
+
+        // Assert service returns true on successful save
+        $result = PhotoSaverService::saveImage($projectRef, $uploadedFile, $fileName, $disk);
+        $this->assertTrue($result);
+    }
+}

--- a/tests/Services/Project/ProjectAvatarServiceS3Test.php
+++ b/tests/Services/Project/ProjectAvatarServiceS3Test.php
@@ -132,4 +132,28 @@ class ProjectAvatarServiceS3Test extends TestCase
         $result = $service->generate($projectRef, 'Test Project');
         $this->assertTrue($result);
     }
+
+    /**
+     * @throws Exception
+     */
+    public function test_service_handles_s3_put_returns_false()
+    {
+        $projectRef = 'test-project-ref';
+
+        // Mock Storage facade - put() returns false
+        Storage::shouldReceive('disk')
+            ->with('project_thumb')
+            ->times(4) // Called 4 times (1 initial + 3 retries)
+            ->andReturnSelf();
+
+        Storage::shouldReceive('put')
+            ->times(4) // Expect 4 calls (1 initial + 3 retries)
+            ->andReturn(false);
+
+        $service = new ProjectAvatarService();
+
+        // Assert service returns false when put() fails
+        $result = $service->generate($projectRef, 'Test Project');
+        $this->assertFalse($result);
+    }
 }

--- a/tests/Services/Project/ProjectAvatarServiceS3Test.php
+++ b/tests/Services/Project/ProjectAvatarServiceS3Test.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Services\Project;
+
+use ec5\Services\Project\ProjectAvatarService;
+use Exception;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use Mockery;
+use Storage;
+use Aws\S3\Exception\S3Exception;
+use Aws\Command;
+use GuzzleHttp\Psr7\Response;
+
+class ProjectAvatarServiceS3Test extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->overrideStorageDriver('s3');
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_service_handles_s3_429_too_many_requests_error()
+    {
+        $projectRef = 'test-project-ref';
+
+        // Mock Storage facade to throw S3Exception with 429
+        Storage::shouldReceive('disk')
+            ->with('project_thumb')
+            ->andReturnSelf();
+
+        Storage::shouldReceive('put')
+            ->times(4) // Expect 4 calls (1 initial + 3 retries)
+            ->andThrow(new S3Exception(
+                'Too Many Requests',
+                new Command('PutObject'),
+                ['response' => new Response(429)]
+            ));
+
+        $service = new ProjectAvatarService();
+
+        // Assert service returns false when S3 errors occur
+        $result = $service->generate($projectRef, 'Test Project');
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_service_handles_s3_503_service_unavailable_error()
+    {
+        $projectRef = 'test-project-ref';
+
+        // Mock Storage facade to throw S3Exception with 503
+        Storage::shouldReceive('disk')
+            ->with('project_thumb')
+            ->andReturnSelf();
+
+        Storage::shouldReceive('put')
+            ->times(4) // Expect 4 calls (1 initial + 3 retries)
+            ->andThrow(new S3Exception(
+                'Service Unavailable',
+                new Command('PutObject'),
+                ['response' => new Response(503)]
+            ));
+
+        $service = new ProjectAvatarService();
+
+        $result = $service->generate($projectRef, 'Test Project');
+        $this->assertFalse($result);
+    }
+}

--- a/tests/Services/Project/ProjectAvatarServiceS3Test.php
+++ b/tests/Services/Project/ProjectAvatarServiceS3Test.php
@@ -5,8 +5,8 @@ namespace Tests\Services\Project;
 use ec5\Services\Project\ProjectAvatarService;
 use Exception;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Tests\TestCase;
-use Mockery;
 use Storage;
 use Aws\S3\Exception\S3Exception;
 use Aws\Command;
@@ -15,17 +15,12 @@ use GuzzleHttp\Psr7\Response;
 class ProjectAvatarServiceS3Test extends TestCase
 {
     use DatabaseTransactions;
+    use MockeryPHPUnitIntegration;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->overrideStorageDriver('s3');
-    }
-
-    protected function tearDown(): void
-    {
-        Mockery::close();
-        parent::tearDown();
     }
 
     /**

--- a/tests/Services/Project/ProjectAvatarServiceS3Test.php
+++ b/tests/Services/Project/ProjectAvatarServiceS3Test.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Services\Project;
 
+use ec5\Libraries\Utilities\Generators;
 use ec5\Services\Project\ProjectAvatarService;
 use Exception;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -23,12 +24,9 @@ class ProjectAvatarServiceS3Test extends TestCase
         $this->overrideStorageDriver('s3');
     }
 
-    /**
-     * @throws Exception
-     */
     public function test_service_handles_s3_429_too_many_requests_error()
     {
-        $projectRef = 'test-project-ref';
+        $projectRef = Generators::projectRef();
 
         // Mock Storage facade to throw S3Exception with 429
         Storage::shouldReceive('disk')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of media and avatar uploads to cloud storage by adding automatic retries with exponential backoff, better stream reopen/close handling, and retry-aware S3 error handling; avatar encoding now respects configured quality settings.
* **Tests**
  * Added comprehensive tests covering success, retryable (429/503), non-retryable (403), and upload-failure scenarios for S3 uploads.
* **Chores**
  * Added CI/review configuration to streamline automated reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->