### PR TITLE
Fixed bug project logo not been deleted when the project is deleted (…

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -3,6 +3,17 @@
 
 language: en-US
 reviews:
+  # Optional: Configure other review settings
+  auto_review:
+    enabled: true
+    drafts: false
+
+  # Optional: Configure which files to review
+  path_filters:
+    - "!vendor/**"
+    - "!node_modules/**"
+    - "!storage/**"
+    - "!bootstrap/cache/**"
   # Disable PHPMD (PHP Mess Detector) checks
   tools:
     phpmd:
@@ -11,14 +22,4 @@ reviews:
     - path: "**/*.php"
       instructions: |
         This project targets PHP 8.3+. Do not flag PHP 8.3+ features like typed class constants as compatibility issues.
-# Optional: Configure other review settings
-auto_review:
-  enabled: true
-  drafts: false
 
-# Optional: Configure which files to review
-path_filters:
-  - "!vendor/**"
-  - "!node_modules/**"
-  - "!storage/**"
-  - "!bootstrap/cache/**"

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -3,15 +3,14 @@
 
 language: en-US
 reviews:
+  # Disable PHPMD (PHP Mess Detector) checks
+  tools:
+    phpmd:
+      enabled: false
   path_instructions:
     - path: "**/*.php"
       instructions: |
         This project targets PHP 8.3+. Do not flag PHP 8.3+ features like typed class constants as compatibility issues.
-# Disable PHPMD (PHP Mess Detector) checks
-tools:
-  phpmd:
-    enabled: false
-
 # Optional: Configure other review settings
 auto_review:
   enabled: true

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -2,6 +2,12 @@
 # https://docs.coderabbit.ai/guides/review-guide
 
 reviews:
+  language: en-US
+  reviews:
+    path_instructions:
+      - path: "**/*.php"
+        instructions: |
+          This project targets PHP 8.3+. Do not flag PHP 8.3+ features like typed class constants as compatibility issues.
   # Disable PHPMD (PHP Mess Detector) checks
   tools:
     phpmd:

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,26 +1,25 @@
 # CodeRabbit configuration file
 # https://docs.coderabbit.ai/guides/review-guide
 
+language: en-US
 reviews:
-  language: en-US
-  reviews:
-    path_instructions:
-      - path: "**/*.php"
-        instructions: |
-          This project targets PHP 8.3+. Do not flag PHP 8.3+ features like typed class constants as compatibility issues.
-  # Disable PHPMD (PHP Mess Detector) checks
-  tools:
-    phpmd:
-      enabled: false
+  path_instructions:
+    - path: "**/*.php"
+      instructions: |
+        This project targets PHP 8.3+. Do not flag PHP 8.3+ features like typed class constants as compatibility issues.
+# Disable PHPMD (PHP Mess Detector) checks
+tools:
+  phpmd:
+    enabled: false
 
-  # Optional: Configure other review settings
-  auto_review:
-    enabled: true
-    drafts: false
+# Optional: Configure other review settings
+auto_review:
+  enabled: true
+  drafts: false
 
-  # Optional: Configure which files to review
-  path_filters:
-    - "!vendor/**"
-    - "!node_modules/**"
-    - "!storage/**"
-    - "!bootstrap/cache/**"
+# Optional: Configure which files to review
+path_filters:
+  - "!vendor/**"
+  - "!node_modules/**"
+  - "!storage/**"
+  - "!bootstrap/cache/**"

--- a/tests/Http/Controllers/Web/Project/ProjectDeleteControllerLocalTest.php
+++ b/tests/Http/Controllers/Web/Project/ProjectDeleteControllerLocalTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Tests\Http\Controllers\Web\Project;
+
+use ec5\Models\OAuth\OAuthClientProject;
+use ec5\Models\Project\Project;
+use ec5\Models\Project\ProjectRole;
+use ec5\Models\Project\ProjectStats;
+use ec5\Models\Project\ProjectStructure;
+use ec5\Models\User\User;
+use ec5\Models\User\UserProvider;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Storage;
+use Mockery;
+use Tests\TestCase;
+
+class ProjectDeleteControllerLocalTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public const string DRIVER = 'web';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->overrideStorageDriver('local');
+    }
+
+    public function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_hard_delete_with_local_storage_mocked()
+    {
+        Storage::fake('project');
+        //creator
+        $role = config('epicollect.strings.project_roles.creator');
+        $trashedStatus = config('epicollect.strings.project_status.trashed');
+
+        //get existing counts
+        $projectsCount = Project::count();
+
+        //create a fake user and save it to DB
+        $user = factory(User::class)->create();
+        //add a user provider
+        factory(UserProvider::class)->create([
+            'user_id' => $user->id,
+            'email' => $user->email
+        ]);
+
+        //create mock project with that user
+        $project = factory(Project::class)->create(
+            [
+                'created_by' => $user->id,
+                'status' => $trashedStatus
+            ]
+        );
+
+        // Create a fake project logo file
+        Storage::disk('project')->put($project->ref.'/logo.jpg', 'fake logo content');
+
+        //assign the user to that project with the CREATOR role
+        factory(ProjectRole::class)->create([
+            'user_id' => $user->id,
+            'project_id' => $project->id,
+            'role' => $role
+        ]);
+
+        //set up project stats and project structures
+        factory(ProjectStats::class)->create([
+            'project_id' => $project->id,
+            'total_entries' => 0
+        ]);
+        factory(ProjectStructure::class)->create([
+            'project_id' => $project->id
+        ]);
+        factory(OAuthClientProject::class)->create([
+            'project_id' => $project->id
+        ]);
+
+        // Verify logo exists before deletion
+        $this->assertTrue(Storage::disk('project')->exists($project->ref.'/logo.jpg'));
+
+        // Act: Simulate the execution of the hardDelete method
+        $response = $this->actingAs($user, self::DRIVER)
+            ->post('/myprojects/' . $project->slug . '/delete', [
+                '_token' => csrf_token(),
+                'project-name' => $project->name
+            ]);
+
+        //Check if the redirect is successful
+        $response->assertRedirect('/myprojects');
+
+        //Check if the project is deleted
+        $this->assertEquals(0, Project::where('id', $project->id)->count());
+
+        //assert stats are dropped
+        $this->assertEquals(0, ProjectStats::where('project_id', $project->id)->count());
+
+        //assert structure is dropped
+        $this->assertEquals(0, ProjectStructure::where('project_id', $project->id)->count());
+
+        //assert app clients are dropped
+        $this->assertEquals(0, OAuthClientProject::where('project_id', $project->id)->count());
+
+        //assert roles are dropped
+        $this->assertEquals(0, ProjectRole::where('project_id', $project->id)->count());
+
+        // Verify logo file is deleted
+        $this->assertFalse(Storage::disk('project')->exists($project->ref));
+
+        // You can also check for messages in the session
+        $response->assertSessionHas('message', 'ec5_114');
+
+        //check counts - project should be deleted, so count stays the same
+        $this->assertEquals($projectsCount, Project::count());
+    }
+
+    public function test_hard_delete_with_local_storage_real()
+    {
+        //creator
+        $role = config('epicollect.strings.project_roles.creator');
+        $trashedStatus = config('epicollect.strings.project_status.trashed');
+
+        //get existing counts
+        $projectsCount = Project::count();
+
+        //create a fake user and save it to DB
+        $user = factory(User::class)->create();
+        //add a user provider
+        factory(UserProvider::class)->create([
+            'user_id' => $user->id,
+            'email' => $user->email
+        ]);
+
+        //create mock project with that user
+        $project = factory(Project::class)->create(
+            [
+                'created_by' => $user->id,
+                'status' => $trashedStatus
+            ]
+        );
+
+        // Create a fake project logo file
+        Storage::disk('project')->put($project->ref, 'fake logo content');
+
+        //assign the user to that project with the CREATOR role
+        factory(ProjectRole::class)->create([
+            'user_id' => $user->id,
+            'project_id' => $project->id,
+            'role' => $role
+        ]);
+
+        //set up project stats and project structures
+        factory(ProjectStats::class)->create([
+            'project_id' => $project->id,
+            'total_entries' => 0
+        ]);
+        factory(ProjectStructure::class)->create([
+            'project_id' => $project->id
+        ]);
+        factory(OAuthClientProject::class)->create([
+            'project_id' => $project->id
+        ]);
+
+        // Verify logo exists before deletion
+        $this->assertTrue(Storage::disk('project')->exists($project->ref));
+
+        // Act: Simulate the execution of the hardDelete method
+        $response = $this->actingAs($user, self::DRIVER)
+            ->post('/myprojects/' . $project->slug . '/delete', [
+                '_token' => csrf_token(),
+                'project-name' => $project->name
+            ]);
+
+        //Check if the redirect is successful
+        $response->assertRedirect('/myprojects');
+
+        //Check if the project is deleted
+        $this->assertEquals(0, Project::where('id', $project->id)->count());
+
+        //assert stats are dropped
+        $this->assertEquals(0, ProjectStats::where('project_id', $project->id)->count());
+
+        //assert structure is dropped
+        $this->assertEquals(0, ProjectStructure::where('project_id', $project->id)->count());
+
+        //assert app clients are dropped
+        $this->assertEquals(0, OAuthClientProject::where('project_id', $project->id)->count());
+
+        //assert roles are dropped
+        $this->assertEquals(0, ProjectRole::where('project_id', $project->id)->count());
+
+        // Verify logo file is deleted
+        $this->assertFalse(Storage::disk('project')->exists('project_thumb/' .$project->ref));
+
+        // You can also check for messages in the session
+        $response->assertSessionHas('message', 'ec5_114');
+
+        //check counts - project should be deleted, so count stays the same
+        $this->assertEquals($projectsCount, Project::count());
+    }
+}

--- a/tests/Http/Controllers/Web/Project/ProjectDeleteControllerLocalTest.php
+++ b/tests/Http/Controllers/Web/Project/ProjectDeleteControllerLocalTest.php
@@ -144,7 +144,7 @@ class ProjectDeleteControllerLocalTest extends TestCase
         );
 
         // Create a fake project logo file
-        Storage::disk('project')->put($project->ref, 'fake logo content');
+        Storage::disk('project')->put($project->ref.'/logo.jpg', 'fake logo content');
 
         //assign the user to that project with the CREATOR role
         factory(ProjectRole::class)->create([

--- a/tests/Http/Controllers/Web/Project/ProjectDeleteControllerS3Test.php
+++ b/tests/Http/Controllers/Web/Project/ProjectDeleteControllerS3Test.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Tests\Http\Controllers\Web\Project;
+
+use ec5\Models\OAuth\OAuthClientProject;
+use ec5\Models\Project\Project;
+use ec5\Models\Project\ProjectRole;
+use ec5\Models\Project\ProjectStats;
+use ec5\Models\Project\ProjectStructure;
+use ec5\Models\User\User;
+use ec5\Models\User\UserProvider;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Storage;
+use Mockery;
+use Tests\TestCase;
+use Aws\S3\Exception\S3Exception;
+use Aws\Command;
+use GuzzleHttp\Psr7\Response;
+
+class ProjectDeleteControllerS3Test extends TestCase
+{
+    use DatabaseTransactions;
+
+    public const string DRIVER = 'web';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->overrideStorageDriver('s3');
+    }
+
+    public function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_hard_delete_with_s3_storage_success_mocked()
+    {
+        //creator
+        $role = config('epicollect.strings.project_roles.creator');
+        $trashedStatus = config('epicollect.strings.project_status.trashed');
+
+        //create a fake user and save it to DB
+        $user = factory(User::class)->create();
+        factory(UserProvider::class)->create([
+            'user_id' => $user->id,
+            'email' => $user->email
+        ]);
+
+        //create mock project with that user
+        $project = factory(Project::class)->create([
+            'created_by' => $user->id,
+            'status' => $trashedStatus
+        ]);
+
+        // Mock S3 storage for successful deletion
+        Storage::shouldReceive('disk')
+            ->with('project')
+            ->once()
+            ->andReturnSelf();
+        Storage::shouldReceive('deleteDirectory')
+            ->with($project->ref)
+            ->once()
+            ->andReturn(true);
+
+        //assign the user to that project with the CREATOR role
+        factory(ProjectRole::class)->create([
+            'user_id' => $user->id,
+            'project_id' => $project->id,
+            'role' => $role
+        ]);
+
+        //set up project stats and project structures
+        factory(ProjectStats::class)->create([
+            'project_id' => $project->id,
+            'total_entries' => 0
+        ]);
+        factory(ProjectStructure::class)->create([
+            'project_id' => $project->id
+        ]);
+        factory(OAuthClientProject::class)->create([
+            'project_id' => $project->id
+        ]);
+
+        // Act: Simulate the execution of the hardDelete method
+        $response = $this->actingAs($user, self::DRIVER)
+            ->post('/myprojects/' . $project->slug . '/delete', [
+                '_token' => csrf_token(),
+                'project-name' => $project->name
+            ]);
+
+        //Check if the redirect is successful
+        $response->assertRedirect('/myprojects');
+
+        //Check if the project is deleted
+        $this->assertEquals(0, Project::where('id', $project->id)->count());
+
+        // You can also check for messages in the session
+        $response->assertSessionHas('message', 'ec5_114');
+    }
+
+    public function test_hard_delete_with_s3_storage_success_real_bucket()
+    {
+        $role = config('epicollect.strings.project_roles.creator');
+        $trashedStatus = config('epicollect.strings.project_status.trashed');
+
+        //create a fake user and save it to DB
+        $user = factory(User::class)->create();
+        factory(UserProvider::class)->create([
+            'user_id' => $user->id,
+            'email' => $user->email
+        ]);
+
+        //create mock project with that user
+        $project = factory(Project::class)->create([
+            'created_by' => $user->id,
+            'status' => $trashedStatus
+        ]);
+
+        // assign the user to that project with the CREATOR role
+        factory(ProjectRole::class)->create([
+            'user_id' => $user->id,
+            'project_id' => $project->id,
+            'role' => $role
+        ]);
+
+        // set up project stats and project structures
+        factory(ProjectStats::class)->create([
+            'project_id' => $project->id,
+            'total_entries' => 0
+        ]);
+        factory(ProjectStructure::class)->create([
+            'project_id' => $project->id
+        ]);
+        factory(OAuthClientProject::class)->create([
+            'project_id' => $project->id
+        ]);
+
+        // --- Arrange: Put a fake file on S3 for this project ---
+        $disk = Storage::disk('project');
+        $filePath = $project->ref . '/logo.jpg';
+        $disk->put($filePath, 'dummy content');
+
+        // Sanity check: ensure the file exists before delete
+        $this->assertTrue($disk->exists($filePath));
+
+        // Act: Simulate the execution of the hardDelete method
+        $response = $this->actingAs($user, self::DRIVER)
+            ->post('/myprojects/' . $project->slug . '/delete', [
+                '_token' => csrf_token(),
+                'project-name' => $project->name
+            ]);
+
+        // Assert: redirect worked
+        $response->assertRedirect('/myprojects');
+
+        // Project is deleted from DB
+        $this->assertEquals(0, Project::where('id', $project->id)->count());
+
+        // Assert: Project directory no longer exists in S3
+        $this->assertFalse($disk->exists($filePath));
+
+        // Assert: session message
+        $response->assertSessionHas('message', 'ec5_114');
+    }
+
+
+    public function test_hard_delete_handles_s3_429_error_with_retry()
+    {
+        //creator
+        $role = config('epicollect.strings.project_roles.creator');
+        $trashedStatus = config('epicollect.strings.project_status.trashed');
+
+        //create a fake user and save it to DB
+        $user = factory(User::class)->create();
+        factory(UserProvider::class)->create([
+            'user_id' => $user->id,
+            'email' => $user->email
+        ]);
+
+        //create mock project with that user
+        $project = factory(Project::class)->create([
+            'created_by' => $user->id,
+            'status' => $trashedStatus
+        ]);
+
+        // Mock S3 storage to throw retryable error then succeed
+        Storage::shouldReceive('disk')
+            ->with('project')
+            ->times(4) // 1 initial + 3 retries
+            ->andReturnSelf();
+        Storage::shouldReceive('deleteDirectory')
+            ->times(3) // Fail 3 times
+            ->andThrow(new S3Exception(
+                'Too Many Requests',
+                new Command('DeleteObject'),
+                ['response' => new Response(429)]
+            ));
+        Storage::shouldReceive('deleteDirectory')
+            ->once() // Succeed on 4th try
+            ->andReturn(true);
+
+        factory(ProjectRole::class)->create([
+            'user_id' => $user->id,
+            'project_id' => $project->id,
+            'role' => $role
+        ]);
+
+        factory(ProjectStats::class)->create([
+            'project_id' => $project->id,
+            'total_entries' => 0
+        ]);
+        factory(ProjectStructure::class)->create([
+            'project_id' => $project->id
+        ]);
+
+        // Act: Should succeed after retries
+        $response = $this->actingAs($user, self::DRIVER)
+            ->post('/myprojects/' . $project->slug . '/delete', [
+                '_token' => csrf_token(),
+                'project-name' => $project->name
+            ]);
+
+        $response->assertRedirect('/myprojects');
+        $this->assertEquals(0, Project::where('id', $project->id)->count());
+    }
+}


### PR DESCRIPTION
…hard delete)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Hard delete now removes project logos from both local and S3 storage.

- Improvements
  - Deletion is transactional: projects are only removed after logo cleanup succeeds.
  - S3 logo removal retries with backoff for transient errors and improved error handling.
  - Hard-delete flow more reliable across storage backends.

- Tests
  - End-to-end tests added for hard-delete with mocked and real local and S3 storage.

- Chores
  - Repository review configuration and guidelines updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->