### PR TITLE
Add tests and middleware updates to handle trashed and archived proje…

### DIFF
--- a/app/DTO/ProjectDTO.php
+++ b/app/DTO/ProjectDTO.php
@@ -4,13 +4,13 @@ namespace ec5\DTO;
 
 use ec5\Http\Validation\Project\RuleProjectDefinition;
 use ec5\Libraries\Utilities\Common;
+use ec5\Services\Mapping\ProjectMappingService;
 use Exception;
 use Illuminate\Support\Str;
 use Ramsey\Uuid\Uuid;
 use ReflectionClass;
 use ReflectionProperty;
 use stdClass;
-use ec5\Services\Mapping\ProjectMappingService;
 
 /*
 |--------------------------------------------------------------------------
@@ -456,6 +456,11 @@ class ProjectDTO
     public function isTrashed(): bool
     {
         return $this->status === config('epicollect.strings.project_status.trashed');
+    }
+
+    public function isArchived(): bool
+    {
+        return $this->status === config('epicollect.strings.project_status.archived');
     }
 
     public function canBulkUpload(): string

--- a/app/Http/Middleware/ProjectPermissionsApi.php
+++ b/app/Http/Middleware/ProjectPermissionsApi.php
@@ -5,14 +5,14 @@ namespace ec5\Http\Middleware;
 use ec5\DTO\ProjectDTO;
 use ec5\Models\OAuth\OAuthClientProject;
 use Illuminate\Http\Request;
+use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\StreamFactory;
+use Laminas\Diactoros\UploadedFileFactory;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use Log;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
-use Laminas\Diactoros\ResponseFactory;
-use Laminas\Diactoros\StreamFactory;
-use Laminas\Diactoros\UploadedFileFactory;
-use Laminas\Diactoros\ServerRequestFactory;
 
 class ProjectPermissionsApi extends RequestAttributesMiddleware
 {
@@ -55,6 +55,14 @@ class ProjectPermissionsApi extends RequestAttributesMiddleware
      */
     public function hasPermission(): bool
     {
+        if (
+            $this->requestedProject->isTrashed() ||
+            $this->requestedProject->isArchived()
+        ) {
+            $this->error = 'ec5_11';
+            return false;
+        }
+
         $responseFactory = new ResponseFactory();
         $streamFactory = new StreamFactory();
         $uploadedFileFactory = new UploadedFileFactory();

--- a/tests/Http/Controllers/Api/Project/ProjectControllerExportTest.php
+++ b/tests/Http/Controllers/Api/Project/ProjectControllerExportTest.php
@@ -320,6 +320,52 @@ class ProjectControllerExportTest extends TestCase
         $this->clearDatabase(['user' => $this->user, 'project' => $this->project]);
     }
 
+    public function test_should_catch_export_project_when_project_is_trashed()
+    {
+        $this->setupProject();
+
+        $this->project->status = config('epicollect.strings.project_status.trashed');
+        $this->project->save();
+
+        $response = $this->json('GET', '/api/export/project/' . $this->project->slug);
+
+        $response->assertStatus(404)
+            ->assertExactJson([
+                "errors" => [
+                    [
+                        "code" => "ec5_11",
+                        "title" => "Project does not exist.",
+                        "source" => "middleware"
+                    ]
+                ]
+            ]);
+
+        $this->clearDatabase(['user' => $this->user, 'project' => $this->project]);
+    }
+
+    public function test_should_catch_export_project_when_project_is_archived()
+    {
+        $this->setupProject();
+
+        $this->project->status = config('epicollect.strings.project_status.archived');
+        $this->project->save();
+
+        $response = $this->json('GET', '/api/export/project/' . $this->project->slug);
+
+        $response->assertStatus(404)
+            ->assertExactJson([
+                "errors" => [
+                    [
+                        "code" => "ec5_11",
+                        "title" => "Project does not exist.",
+                        "source" => "middleware"
+                    ]
+                ]
+            ]);
+
+        $this->clearDatabase(['user' => $this->user, 'project' => $this->project]);
+    }
+
     //imp: the one below is a custom setup project method called only when needed
     //imp: since some tests do not need it, but we are not using transactions
     private function setupProject()

--- a/tests/Http/Middleware/ProjectPermissionsApiTest.php
+++ b/tests/Http/Middleware/ProjectPermissionsApiTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Http\Middleware;
+
+use ec5\DTO\ProjectDTO;
+use ec5\Http\Middleware\ProjectPermissionsApi;
+use Illuminate\Http\Request;
+use League\OAuth2\Server\ResourceServer;
+use stdClass;
+use Tests\TestCase;
+
+class ProjectPermissionsApiTest extends TestCase
+{
+    public function test_it_should_bail_if_requested_project_is_trashed()
+    {
+        $middleware = $this->makeMiddlewareWithProjectStatus(config('epicollect.strings.project_status.trashed'));
+
+        $this->assertFalse($middleware->hasPermission());
+        $this->assertSame('ec5_11', $middleware->getErrorCode());
+    }
+
+    public function test_it_should_bail_if_requested_project_is_archived()
+    {
+        $middleware = $this->makeMiddlewareWithProjectStatus(config('epicollect.strings.project_status.archived'));
+
+        $this->assertFalse($middleware->hasPermission());
+        $this->assertSame('ec5_11', $middleware->getErrorCode());
+    }
+
+    private function makeMiddlewareWithProjectStatus(string $status): ProjectPermissionsApi
+    {
+        $requestedProject = app(ProjectDTO::class);
+        $requestedProject->initAllDTOs($this->makeProjectData($status));
+
+        return new class ($this->createMock(ResourceServer::class), Request::create('/api/export/project/test-project', 'GET'), $requestedProject) extends ProjectPermissionsApi {
+            public function getErrorCode(): string
+            {
+                return $this->error;
+            }
+        };
+    }
+
+    private function makeProjectData(string $status): stdClass
+    {
+        return (object) [
+            'id' => 1,
+            'project_id' => 1,
+            'structure_id' => 1,
+            'name' => 'Test Project',
+            'slug' => 'test-project',
+            'ref' => 'test-project-ref',
+            'description' => '',
+            'small_description' => '',
+            'logo_url' => '',
+            'access' => config('epicollect.strings.project_access.private'),
+            'visibility' => config('epicollect.strings.project_visibility.listed'),
+            'category' => 'general',
+            'created_by' => 1,
+            'created_at' => now()->toDateTimeString(),
+            'updated_at' => now()->toDateTimeString(),
+            'status' => $status,
+            'can_bulk_upload' => 'nobody',
+            'app_link_visibility' => 'hidden',
+            'project_definition' => json_encode(['project' => [], 'forms' => []]),
+            'project_extra' => json_encode([]),
+            'project_mapping' => json_encode([]),
+            'total_entries' => 0,
+            'total_bytes' => 0,
+            'form_counts' => json_encode([]),
+            'branch_counts' => json_encode([]),
+            'structure_last_updated' => now()->toDateTimeString(),
+        ];
+    }
+}


### PR DESCRIPTION
…ct to bail out on export

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trashed and archived projects are now properly blocked from API access, returning a 404 error when attempted to be accessed or exported through the API.

* **Tests**
  * Added comprehensive test coverage for API access restrictions on trashed and archived projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->