### PR TITLE
Add updated_at column to project_stats, backfill data via migration, …

### DIFF
--- a/app/Console/Commands/SystemProjectStorageCommand.php
+++ b/app/Console/Commands/SystemProjectStorageCommand.php
@@ -96,7 +96,8 @@ class SystemProjectStorageCommand extends Command
                 'photo_files' => $mediaStats['counters']['photo'],
                 'audio_files' => $mediaStats['counters']['audio'],
                 'video_files' => $mediaStats['counters']['video'],
-                'total_bytes_updated_at' => now()
+                'total_bytes_updated_at' => now(),
+                'updated_at' => now()
             ]);
     }
 }

--- a/app/Models/Project/ProjectStats.php
+++ b/app/Models/Project/ProjectStats.php
@@ -22,8 +22,10 @@ class ProjectStats extends Model
     use SerializeDates;
 
     protected $table = 'project_stats';
-    public $timestamps = false;
+    public $timestamps = true;
     public $guarded = [];
+    /** @noinspection PhpMissingClassConstantTypeInspection */
+    public const CREATED_AT = null;
 
     public function getMostRecentEntryTimestamp(): string
     {
@@ -110,7 +112,8 @@ class ProjectStats extends Model
             ->update(
                 [
                     'form_counts' => json_encode($statsCount),
-                    'total_entries' => $totalCount
+                    'total_entries' => $totalCount,
+                    'updated_at' => now()
                 ]
             );
     }
@@ -142,7 +145,10 @@ class ProjectStats extends Model
 
         DB::table($this->table)
             ->where('project_id', '=', $projectId)
-            ->update(['branch_counts' => json_encode($statsCount)]);
+            ->update([
+                'branch_counts' => json_encode($statsCount),
+                'updated_at' => now()
+            ]);
     }
 
     /**
@@ -193,6 +199,7 @@ class ProjectStats extends Model
                     'total_bytes' => DB::raw('photo_bytes + audio_bytes + video_bytes'),
                     'total_files' => DB::raw('photo_files + audio_files + video_files'),
                     'total_bytes_updated_at' => now(),
+                    'updated_at' => now(),
                 ]);
 
         } catch (Throwable $e) {
@@ -290,6 +297,7 @@ class ProjectStats extends Model
                     'total_bytes' => $photoBytes + $audioBytes + $videoBytes,
                     'total_files' => $photoFiles + $audioFiles + $videoFiles,
                     'total_bytes_updated_at' => now(),
+                    'updated_at' => now(),
                 ]);
 
         } catch (Throwable $e) {

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -366,7 +366,8 @@ $factory->define(ProjectStats::class, function () {
         'video_files' => 0,
         'video_bytes' => 0,
         'form_counts' => json_encode([]),
-        'branch_counts' => json_encode([])
+        'branch_counts' => json_encode([]),
+        'updated_at' => Carbon::now()
     ];
 });
 

--- a/database/migrations/2026_04_20_120000_add_updated_at_to_project_stats_table.php
+++ b/database/migrations/2026_04_20_120000_add_updated_at_to_project_stats_table.php
@@ -1,0 +1,92 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use ec5\Models\Project\ProjectStructure;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('project_stats', function (Blueprint $table) {
+            $table->timestamp('updated_at')->useCurrent()->after('branch_counts');
+        });
+
+        DB::table('project_stats')
+            ->select([
+                'id',
+                'project_id',
+                'form_counts',
+                'branch_counts',
+                'total_bytes_updated_at',
+            ])
+            ->orderBy('id')
+            ->chunkById(100, function ($projectStatsRows) {
+                foreach ($projectStatsRows as $projectStatsRow) {
+                    $timestamps = [];
+
+                    foreach ([$projectStatsRow->form_counts, $projectStatsRow->branch_counts] as $countsJson) {
+                        $counts = json_decode($countsJson ?? '', true);
+
+                        if (!is_array($counts)) {
+                            continue;
+                        }
+
+                        foreach ($counts as $count) {
+                            $lastEntryCreated = $count['last_entry_created'] ?? null;
+
+                            if (!empty($lastEntryCreated)) {
+                                $timestamps[] = Carbon::parse($lastEntryCreated);
+                            }
+                        }
+                    }
+
+                    if (!empty($projectStatsRow->total_bytes_updated_at)) {
+                        $timestamps[] = Carbon::parse($projectStatsRow->total_bytes_updated_at);
+                    }
+
+                    $updatedAt = collect($timestamps)
+                        ->sortByDesc(function (Carbon $timestamp) {
+                            return $timestamp->getTimestamp();
+                        })
+                        ->first();
+
+                    if (empty($updatedAt)) {
+                        $updatedAt = ProjectStructure::where(
+                            'project_id',
+                            $projectStatsRow->project_id
+                        )
+                            ->value('updated_at');
+                        DB::table('project_stats')
+                            ->where('id', $projectStatsRow->id)
+                            ->update([
+                                'updated_at' => $updatedAt
+                            ]);
+                    } else {
+                        DB::table('project_stats')
+                            ->where('id', $projectStatsRow->id)
+                            ->update([
+                                'updated_at' => $updatedAt->format('Y-m-d H:i:s')
+                            ]);
+                    }
+                }
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('project_stats', 'updated_at')) {
+            Schema::table('project_stats', function (Blueprint $table) {
+                $table->dropColumn('updated_at');
+            });
+        }
+    }
+};

--- a/database/migrations/2026_04_20_120000_add_updated_at_to_project_stats_table.php
+++ b/database/migrations/2026_04_20_120000_add_updated_at_to_project_stats_table.php
@@ -50,11 +50,7 @@ return new class () extends Migration {
                         $timestamps[] = Carbon::parse($projectStatsRow->total_bytes_updated_at);
                     }
 
-                    $updatedAt = collect($timestamps)
-                        ->sortByDesc(function (Carbon $timestamp) {
-                            return $timestamp->getTimestamp();
-                        })
-                        ->first();
+                    $updatedAt = collect($timestamps)->max();
 
                     if (empty($updatedAt)) {
                         $updatedAt = ProjectStructure::where(

--- a/tests/Models/Eloquent/ProjectStatsTest.php
+++ b/tests/Models/Eloquent/ProjectStatsTest.php
@@ -31,7 +31,8 @@ class ProjectStatsTest extends TestCase
             'video_files' => 30,
             'total_bytes' => 600,
             'total_files' => 60,
-            'total_bytes_updated_at' => $this->now
+            'total_bytes_updated_at' => $this->now,
+            'updated_at' => $this->now->copy()->subHour()
         ]);
         $this->assertDatabaseHas('project_stats', [
             'id' => $this->projectStats->id,
@@ -67,9 +68,7 @@ class ProjectStatsTest extends TestCase
             'total_files' => 0
         ]);
 
-        ///assert that total_bytes_updated_at is updated to a recent time (within the last minute)
-        $updatedAt = Carbon::parse($this->projectStats->fresh()->total_bytes_updated_at);
-        $this->assertTrue($updatedAt->greaterThan(now()->subMinute()));
+        $this->assertProjectStatsTouched();
     }
 
 
@@ -87,9 +86,7 @@ class ProjectStatsTest extends TestCase
             'total_bytes' => 590,
             'total_files' => 59
         ]);
-        //assert that total_bytes_updated_at is updated to a recent time (within the last minute)
-        $updatedAt = Carbon::parse($this->projectStats->fresh()->total_bytes_updated_at);
-        $this->assertTrue($updatedAt->greaterThan(now()->subMinute()));
+        $this->assertProjectStatsTouched();
     }
 
     public function test_audio_deleted()
@@ -106,9 +103,7 @@ class ProjectStatsTest extends TestCase
             'total_bytes' => 580,
             'total_files' => 58
         ]);
-        //assert that total_bytes_updated_at is updated to a recent time (within the last minute)
-        $updatedAt = Carbon::parse($this->projectStats->fresh()->total_bytes_updated_at);
-        $this->assertTrue($updatedAt->greaterThan(now()->subMinute()));
+        $this->assertProjectStatsTouched();
     }
 
     public function test_video_deleted()
@@ -125,9 +120,7 @@ class ProjectStatsTest extends TestCase
             'total_bytes' => 570,
             'total_files' => 57
         ]);
-        //assert that total_bytes_updated_at is updated to a recent time (within the last minute)
-        $updatedAt = Carbon::parse($this->projectStats->fresh()->total_bytes_updated_at);
-        $this->assertTrue($updatedAt->greaterThan(now()->subMinute()));
+        $this->assertProjectStatsTouched();
     }
 
     public function test_one_file_per_media_type_deleted()
@@ -144,9 +137,7 @@ class ProjectStatsTest extends TestCase
             'total_bytes' => 540,
             'total_files' => 54
         ]);
-        //assert that total_bytes_updated_at is updated to a recent time (within the last minute)
-        $updatedAt = Carbon::parse($this->projectStats->fresh()->total_bytes_updated_at);
-        $this->assertTrue($updatedAt->greaterThan(now()->subMinute()));
+        $this->assertProjectStatsTouched();
     }
 
     public function test_photo_added()
@@ -163,9 +154,7 @@ class ProjectStatsTest extends TestCase
             'total_bytes' => 610,
             'total_files' => 61
         ]);
-        //assert that total_bytes_updated_at is updated to a recent time (within the last minute)
-        $updatedAt = Carbon::parse($this->projectStats->fresh()->total_bytes_updated_at);
-        $this->assertTrue($updatedAt->greaterThan(now()->subMinute()));
+        $this->assertProjectStatsTouched();
     }
 
     public function test_audio_added()
@@ -182,9 +171,7 @@ class ProjectStatsTest extends TestCase
             'total_bytes' => 620,
             'total_files' => 62
         ]);
-        //assert that total_bytes_updated_at is updated to a recent time (within the last minute)
-        $updatedAt = Carbon::parse($this->projectStats->fresh()->total_bytes_updated_at);
-        $this->assertTrue($updatedAt->greaterThan(now()->subMinute()));
+        $this->assertProjectStatsTouched();
     }
 
     public function test_video_added()
@@ -201,9 +188,7 @@ class ProjectStatsTest extends TestCase
             'total_bytes' => 630,
             'total_files' => 63
         ]);
-        //assert that total_bytes_updated_at is updated to a recent time (within the last minute)
-        $updatedAt = Carbon::parse($this->projectStats->fresh()->total_bytes_updated_at);
-        $this->assertTrue($updatedAt->greaterThan(now()->subMinute()));
+        $this->assertProjectStatsTouched();
     }
 
     public function test_one_file_per_media_type_added()
@@ -221,8 +206,16 @@ class ProjectStatsTest extends TestCase
             'total_files' => 66
         ]);
 
-        //assert that total_bytes_updated_at is updated to a recent time (within the last minute)
-        $updatedAt = Carbon::parse($this->projectStats->fresh()->total_bytes_updated_at);
-        $this->assertTrue($updatedAt->greaterThan(now()->subMinute()));
+        $this->assertProjectStatsTouched();
+    }
+
+    private function assertProjectStatsTouched(): void
+    {
+        $projectStats = $this->projectStats->fresh();
+        $totalBytesUpdatedAt = Carbon::parse($projectStats->total_bytes_updated_at);
+        $updatedAt = Carbon::parse($projectStats->updated_at);
+
+        $this->assertTrue($totalBytesUpdatedAt->greaterThan(now()->subMinute()));
+        $this->assertTrue($updatedAt->greaterThan($this->now->copy()->subMinute()));
     }
 }

--- a/tests/Models/Eloquent/ProjectStatsTest.php
+++ b/tests/Models/Eloquent/ProjectStatsTest.php
@@ -31,7 +31,7 @@ class ProjectStatsTest extends TestCase
             'video_files' => 30,
             'total_bytes' => 600,
             'total_files' => 60,
-            'total_bytes_updated_at' => $this->now,
+            'total_bytes_updated_at' => $this->now->copy()->subHour(),
             'updated_at' => $this->now->copy()->subHour()
         ]);
         $this->assertDatabaseHas('project_stats', [


### PR DESCRIPTION
…and ensure timestamp updates in model methods and console commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added and backfilled an updated_at timestamp for project statistics and ensured all stats-updating operations record this timestamp for consistent metadata and auditability.
  * Enabled model-level timestamp handling so storage, entry counts, and bulk updates maintain update times.

* **Tests**
  * Updated tests and helpers to assert and verify recent updated_at behavior across project statistics operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->