### PR TITLE
Feature/cache entries exports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,8 @@ DO_SPACES_BUCKET=xxx
 
 # "array" to disable cache, set to "file" in production
 CACHE_DRIVER=file
+EXPORT_ENTRIES_CACHE_ENABLED=false
+EXPORT_ENTRIES_CACHE_TTL=3600
 # Media cache duration in hours for unversioned photo URLs. Defaults to 24.
 MEDIA_CACHE_CONTROL_HOURS=24
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -74,9 +74,9 @@ class Kernel extends ConsoleKernel
                 ->timezone('UTC')
                 ->withoutOverlapping();
 
-            //clear laravel expired cache files on Sunday at 04:00 UTC
+            //clear laravel expired cache files daily at 04:00 UTC
             $schedule->command('cache:gc')
-                ->weeklyOn(0, '04:00')
+                ->dailyAt('04:00')
                 ->timezone('UTC')
                 ->withoutOverlapping();
         } else {

--- a/app/Http/Controllers/Api/Entries/View/ViewEntriesDataController.php
+++ b/app/Http/Controllers/Api/Entries/View/ViewEntriesDataController.php
@@ -39,7 +39,7 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
      */
     public function export(Request $request)
     {
-        //set limit to avoid massive pyalod exports
+        //set limit to avoid massive payload exports
         $jsonPerPageLimit = config('epicollect.limits.entries_export_per_page_json');
         $csvPerPageLimit = config('epicollect.limits.entries_export_per_page_csv');
 
@@ -54,13 +54,6 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
         // Validate the options and query string
         if (!$this->entriesViewService->areValidQueryParams($params)) {
             return Response::apiErrorCode(400, $this->entriesViewService->validationErrors);
-        }
-
-        //check if this is the first page of the dataset
-        if ((int)$params['page'] === 1) {
-            // Entry exports are paginated; refresh project_stats once at the start
-            // so exported metadata reflects current totals without changing mid-export.
-            $this->refreshProjectStats($this->requestedProject());
         }
 
         // If the map_index value passed does not exist, error out
@@ -105,7 +98,7 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
         $cacheTTL = $this->entriesCacheService->getExportEntriesCacheTTL();
 
         if (!$this->entriesCacheService->isExportEntriesCacheEnabled() || $cacheTTL <= 0) {
-            return $this->sendExportEntriesResponse($params);
+            return $this->sendExportEntriesResponseWithFreshStats($params);
         }
 
         return $this->entriesCacheService->rememberExportEntriesResponse(
@@ -113,7 +106,7 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
             $request->fullUrl(),
             $cacheTTL,
             function () use ($params) {
-                return $this->sendExportEntriesResponse($params);
+                return $this->sendExportEntriesResponseWithFreshStats($params);
             }
         );
     }
@@ -141,7 +134,20 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
 
     /**
      * Send the mapped export response for the requested format.
+     * @throws Throwable
      */
+    private function sendExportEntriesResponseWithFreshStats(array $params)
+    {
+        //check if this is the first page of the dataset
+        if ((int)$params['page'] === 1) {
+            // Entry exports are paginated; refresh project_stats once at the start
+            // so exported metadata reflects current totals without changing mid-export.
+            $this->refreshProjectStats($this->requestedProject());
+        }
+
+        return $this->sendExportEntriesResponse($params);
+    }
+
     private function sendExportEntriesResponse(array $params)
     {
         // Switch on the format

--- a/app/Http/Controllers/Api/Entries/View/ViewEntriesDataController.php
+++ b/app/Http/Controllers/Api/Entries/View/ViewEntriesDataController.php
@@ -85,16 +85,6 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
                 }
             }
         }
-        // Set the mapping
-        $this->dataMappingService->init(
-            $this->requestedProject(),
-            $params['format'],
-            $params['branch_ref'] !== '' ? 'branch' : 'form',
-            $params['form_ref'],
-            $params['branch_ref'],
-            $params['map_index']
-        );
-
         $cacheTTL = $this->entriesCacheService->getExportEntriesCacheTTL();
 
         if (!$this->entriesCacheService->isExportEntriesCacheEnabled() || $cacheTTL <= 0) {
@@ -150,6 +140,15 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
 
     private function sendExportEntriesResponse(array $params)
     {
+        $this->dataMappingService->init(
+            $this->requestedProject(),
+            $params['format'],
+            $params['branch_ref'] !== '' ? 'branch' : 'form',
+            $params['form_ref'],
+            $params['branch_ref'],
+            $params['map_index']
+        );
+
         // Switch on the format
         switch ($params['format']) {
             case 'csv':

--- a/app/Http/Controllers/Api/Entries/View/ViewEntriesDataController.php
+++ b/app/Http/Controllers/Api/Entries/View/ViewEntriesDataController.php
@@ -9,6 +9,8 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Response;
 use Log;
 use Throwable;
@@ -21,7 +23,7 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
     /**
      * @throws Throwable
      */
-    public function export()
+    public function export(Request $request)
     {
         //Slow down api responses to avoid overloading the server
         $jsonPerPageLimit = config('epicollect.limits.entries_export_per_page_json');
@@ -84,25 +86,21 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
             $params['map_index']
         );
 
-        // Switch on the format
-        switch ($params['format']) {
-            case 'csv':
-                // Branch
-                if ($params['branch_ref'] != '') {
-                    return $this->sendBranchEntriesCSV($params);
-                } else {
-                    // Form
-                    return $this->sendEntriesCSV($params);
-                }
-                // no break
-            default:
-                // Branch
-                if ($params['branch_ref'] != '') {
-                    return $this->sendBranchEntriesJSON($params, true);
-                }
-                // Form
-                return $this->sendEntriesJSON($params, true);
+        $cacheKey = $this->getExportEntriesCacheKey($request);
+        $cacheEnabled = config('cache.export_entries_cache_enabled');
+        $cacheTTL = config('cache.export_entries_cache_ttl');
+
+        if (!$cacheEnabled || $cacheTTL <= 0) {
+            return $this->sendExportEntriesResponse($params);
         }
+
+        return Cache::remember(
+            $cacheKey,
+            $cacheTTL,
+            function () use ($params) {
+                return $this->sendExportEntriesResponse($params);
+            }
+        );
     }
 
     /**
@@ -124,6 +122,32 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
         }
         // Form
         return $this->sendEntriesJSON($params, false);
+    }
+
+    /**
+     * Send the mapped export response for the requested format.
+     */
+    private function sendExportEntriesResponse(array $params)
+    {
+        // Switch on the format
+        switch ($params['format']) {
+            case 'csv':
+                // Branch
+                if ($params['branch_ref'] != '') {
+                    return $this->sendBranchEntriesCSV($params);
+                } else {
+                    // Form
+                    return $this->sendEntriesCSV($params);
+                }
+                // no break
+            default:
+                // Branch
+                if ($params['branch_ref'] != '') {
+                    return $this->sendBranchEntriesJSON($params, true);
+                }
+                // Form
+                return $this->sendEntriesJSON($params, true);
+        }
     }
 
     /**
@@ -346,5 +370,18 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
             return Response::apiErrorCode(400, ['entries-export-csv' => ['ec5_232']]);
         }
         return Response::toCSVStream();
+    }
+
+    /**
+     * Build the file-cache key for a project entries export request.
+     */
+    private function getExportEntriesCacheKey(Request $request): string
+    {
+        $projectSlug = $this->requestedProject()->slug;
+
+        return 'export_entries:' . hash(
+            'sha256',
+            $projectSlug . '|' . $request->fullUrl()
+        );
     }
 }

--- a/app/Http/Controllers/Api/Entries/View/ViewEntriesDataController.php
+++ b/app/Http/Controllers/Api/Entries/View/ViewEntriesDataController.php
@@ -3,6 +3,9 @@
 namespace ec5\Http\Controllers\Api\Entries\View;
 
 use ec5\Libraries\Utilities\DateFormatConverter;
+use ec5\Services\Entries\EntriesCacheService;
+use ec5\Services\Entries\EntriesViewService;
+use ec5\Services\Mapping\DataMappingService;
 use ec5\Traits\Eloquent\StatsRefresher;
 use Exception;
 use Illuminate\Contracts\Foundation\Application;
@@ -10,7 +13,6 @@ use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Response;
 use Log;
 use Throwable;
@@ -19,13 +21,25 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
 {
     use StatsRefresher;
 
+    private EntriesCacheService $entriesCacheService;
+
+    public function __construct(
+        DataMappingService $dataMappingService,
+        EntriesViewService $entriesViewService,
+        EntriesCacheService $entriesCacheService
+    ) {
+        parent::__construct($dataMappingService, $entriesViewService);
+
+        $this->entriesCacheService = $entriesCacheService;
+    }
+
     //Export entries using the API
     /**
      * @throws Throwable
      */
     public function export(Request $request)
     {
-        //Slow down api responses to avoid overloading the server
+        //set limit to avoid massive pyalod exports
         $jsonPerPageLimit = config('epicollect.limits.entries_export_per_page_json');
         $csvPerPageLimit = config('epicollect.limits.entries_export_per_page_csv');
 
@@ -33,6 +47,7 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
         $projectMapping = $this->requestedProject()->getProjectMapping();
 
         $allowedKeys = array_keys(config('epicollect.strings.search_data_entries'));
+        //set a default per_page in case it is missing from the request
         $perPage = config('epicollect.limits.entries_table.per_page');
         $params = $this->entriesViewService->getSanitizedQueryParams($allowedKeys, $perPage);
 
@@ -41,6 +56,7 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
             return Response::apiErrorCode(400, $this->entriesViewService->validationErrors);
         }
 
+        //check if this is the first page of the dataset
         if ((int)$params['page'] === 1) {
             // Entry exports are paginated; refresh project_stats once at the start
             // so exported metadata reflects current totals without changing mid-export.
@@ -86,16 +102,15 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
             $params['map_index']
         );
 
-        $cacheKey = $this->getExportEntriesCacheKey($request);
-        $cacheEnabled = config('cache.export_entries_cache_enabled');
-        $cacheTTL = config('cache.export_entries_cache_ttl');
+        $cacheTTL = $this->entriesCacheService->getExportEntriesCacheTTL();
 
-        if (!$cacheEnabled || $cacheTTL <= 0) {
+        if (!$this->entriesCacheService->isExportEntriesCacheEnabled() || $cacheTTL <= 0) {
             return $this->sendExportEntriesResponse($params);
         }
 
-        return Cache::remember(
-            $cacheKey,
+        return $this->entriesCacheService->rememberExportEntriesResponse(
+            $this->requestedProject()->slug,
+            $request->fullUrl(),
             $cacheTTL,
             function () use ($params) {
                 return $this->sendExportEntriesResponse($params);
@@ -372,16 +387,4 @@ class ViewEntriesDataController extends ViewEntriesControllerBase
         return Response::toCSVStream();
     }
 
-    /**
-     * Build the file-cache key for a project entries export request.
-     */
-    private function getExportEntriesCacheKey(Request $request): string
-    {
-        $projectSlug = $this->requestedProject()->slug;
-
-        return 'export_entries:' . hash(
-            'sha256',
-            $projectSlug . '|' . $request->fullUrl()
-        );
-    }
 }

--- a/app/Services/Entries/EntriesCacheService.php
+++ b/app/Services/Entries/EntriesCacheService.php
@@ -78,6 +78,7 @@ class EntriesCacheService
         return [
             'content' => $content,
             'status' => $response->getStatusCode(),
+            'content_type' => $response->headers->get('Content-Type'),
         ];
     }
 
@@ -86,13 +87,15 @@ class EntriesCacheService
         if (
             !isset(
                 $cachedResponse['content'],
-                $cachedResponse['status']
+                $cachedResponse['status'],
+                $cachedResponse['content_type']
             )
         ) {
             return null;
         }
 
-        return response($cachedResponse['content'], $cachedResponse['status']);
+        return response($cachedResponse['content'], $cachedResponse['status'])
+            ->header('Content-Type', $cachedResponse['content_type']);
     }
 
     private function setCacheHeaders(Response $response, string $status, int $cacheTTL): void

--- a/app/Services/Entries/EntriesCacheService.php
+++ b/app/Services/Entries/EntriesCacheService.php
@@ -10,6 +10,7 @@ class EntriesCacheService
 {
     private const CACHE_HEADER = 'X-Epicollect-Cache';
     private const CACHE_TTL_HEADER = 'X-Epicollect-Cache-Ttl';
+    private const CACHEABLE_STATUS_CODE = 200;
 
     public function isExportEntriesCacheEnabled(): bool
     {
@@ -43,7 +44,15 @@ class EntriesCacheService
         }
 
         $response = $callback();
-        Cache::put($cacheKey, $this->getResponseCachePayload($response), $cacheTTL);
+        $cachePayload = $this->getResponseCachePayload($response);
+
+        if (!$cachePayload) {
+            $this->setCacheHeaders($response, 'bypass', $cacheTTL);
+
+            return $response;
+        }
+
+        Cache::put($cacheKey, $cachePayload, $cacheTTL);
         $this->setCacheHeaders($response, 'miss', $cacheTTL);
 
         return $response;
@@ -54,12 +63,21 @@ class EntriesCacheService
         return 'export_entries:' . hash('sha256', $projectSlug . '|' . $fullUrl);
     }
 
-    private function getResponseCachePayload(Response $response): array
+    private function getResponseCachePayload(Response $response): ?array
     {
+        if ($response->getStatusCode() !== self::CACHEABLE_STATUS_CODE) {
+            return null;
+        }
+
+        $content = $response->getContent();
+
+        if ($content === false) {
+            return null;
+        }
+
         return [
-            'content' => $response->getContent(),
+            'content' => $content,
             'status' => $response->getStatusCode(),
-            'headers' => $response->headers->all(),
         ];
     }
 
@@ -68,20 +86,13 @@ class EntriesCacheService
         if (
             !isset(
                 $cachedResponse['content'],
-                $cachedResponse['status'],
-                $cachedResponse['headers']
+                $cachedResponse['status']
             )
         ) {
             return null;
         }
 
-        $response = response($cachedResponse['content'], $cachedResponse['status']);
-
-        foreach ($cachedResponse['headers'] as $key => $value) {
-            $response->headers->set($key, $value);
-        }
-
-        return $response;
+        return response($cachedResponse['content'], $cachedResponse['status']);
     }
 
     private function setCacheHeaders(Response $response, string $status, int $cacheTTL): void

--- a/app/Services/Entries/EntriesCacheService.php
+++ b/app/Services/Entries/EntriesCacheService.php
@@ -8,6 +8,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EntriesCacheService
 {
+    private const CACHE_HEADER = 'X-Epicollect-Cache';
+    private const CACHE_TTL_HEADER = 'X-Epicollect-Cache-Ttl';
+
     public function isExportEntriesCacheEnabled(): bool
     {
         return (bool) config('cache.export_entries_cache_enabled');
@@ -31,6 +34,8 @@ class EntriesCacheService
             $response = $this->getCachedExportEntriesResponse($cachedResponse);
 
             if ($response) {
+                $this->setCacheHeaders($response, 'hit', $cacheTTL);
+
                 return $response;
             }
 
@@ -39,6 +44,7 @@ class EntriesCacheService
 
         $response = $callback();
         Cache::put($cacheKey, $this->getCompressedResponseCachePayload($response), $cacheTTL);
+        $this->setCacheHeaders($response, 'miss', $cacheTTL);
 
         return $response;
     }
@@ -85,5 +91,11 @@ class EntriesCacheService
         }
 
         return $response;
+    }
+
+    private function setCacheHeaders(Response $response, string $status, int $cacheTTL): void
+    {
+        $response->headers->set(self::CACHE_HEADER, $status);
+        $response->headers->set(self::CACHE_TTL_HEADER, (string) $cacheTTL);
     }
 }

--- a/app/Services/Entries/EntriesCacheService.php
+++ b/app/Services/Entries/EntriesCacheService.php
@@ -82,7 +82,7 @@ class EntriesCacheService
         return [
             'content' => $content,
             'status' => self::CACHEABLE_STATUS_CODE,
-            'content_type' => $response->headers->get('Content-Type'),
+            'headers' => $response->headers->allPreserveCase(),
         ];
     }
 
@@ -92,14 +92,19 @@ class EntriesCacheService
             !isset(
                 $cachedResponse['content'],
                 $cachedResponse['status'],
-                $cachedResponse['content_type']
+                $cachedResponse['headers']
             )
         ) {
             return null;
         }
 
-        return response($cachedResponse['content'], $cachedResponse['status'])
-            ->header('Content-Type', $cachedResponse['content_type']);
+        $response = response($cachedResponse['content'], $cachedResponse['status']);
+
+        foreach ($cachedResponse['headers'] as $name => $values) {
+            $response->headers->set($name, $values);
+        }
+
+        return $response;
     }
 
     private function setCacheHeaders(Response $response, string $status, int $cacheTTL): void

--- a/app/Services/Entries/EntriesCacheService.php
+++ b/app/Services/Entries/EntriesCacheService.php
@@ -8,9 +8,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EntriesCacheService
 {
-    private const CACHE_HEADER = 'X-Epicollect-Cache';
-    private const CACHE_TTL_HEADER = 'X-Epicollect-Cache-Ttl';
-    private const CACHEABLE_STATUS_CODE = 200;
+    private const string CACHE_HEADER = 'X-Epicollect-Cache';
+    private const string CACHE_TTL_HEADER = 'X-Epicollect-Cache-Ttl';
+    private const int CACHEABLE_STATUS_CODE = 200;
 
     public function isExportEntriesCacheEnabled(): bool
     {
@@ -65,19 +65,23 @@ class EntriesCacheService
 
     private function getResponseCachePayload(Response $response): ?array
     {
+        //if the response is not 200, do not cache
         if ($response->getStatusCode() !== self::CACHEABLE_STATUS_CODE) {
             return null;
         }
 
         $content = $response->getContent();
-
         if ($content === false) {
             return null;
         }
 
+        //return the cache payload. Content-Type is needed to preserve the content type of the response
+        //so that the response is sent with the correct content type
+        // JSON: 'application/vnd.api+json; charset=utf-8
+        // CSV: text/csv; charset=utf-8
         return [
             'content' => $content,
-            'status' => $response->getStatusCode(),
+            'status' => self::CACHEABLE_STATUS_CODE,
             'content_type' => $response->headers->get('Content-Type'),
         ];
     }

--- a/app/Services/Entries/EntriesCacheService.php
+++ b/app/Services/Entries/EntriesCacheService.php
@@ -43,7 +43,7 @@ class EntriesCacheService
         }
 
         $response = $callback();
-        Cache::put($cacheKey, $this->getCompressedResponseCachePayload($response), $cacheTTL);
+        Cache::put($cacheKey, $this->getResponseCachePayload($response), $cacheTTL);
         $this->setCacheHeaders($response, 'miss', $cacheTTL);
 
         return $response;
@@ -54,11 +54,10 @@ class EntriesCacheService
         return 'export_entries:' . hash('sha256', $projectSlug . '|' . $fullUrl);
     }
 
-    private function getCompressedResponseCachePayload(Response $response): array
+    private function getResponseCachePayload(Response $response): array
     {
         return [
-            'compressed' => true,
-            'content' => gzencode($response->getContent(), 3),
+            'content' => $response->getContent(),
             'status' => $response->getStatusCode(),
             'headers' => $response->headers->all(),
         ];
@@ -68,23 +67,15 @@ class EntriesCacheService
     {
         if (
             !isset(
-                $cachedResponse['compressed'],
                 $cachedResponse['content'],
                 $cachedResponse['status'],
                 $cachedResponse['headers']
-            ) ||
-            $cachedResponse['compressed'] !== true
+            )
         ) {
             return null;
         }
 
-        $content = gzdecode($cachedResponse['content']);
-
-        if ($content === false) {
-            return null;
-        }
-
-        $response = response($content, $cachedResponse['status']);
+        $response = response($cachedResponse['content'], $cachedResponse['status']);
 
         foreach ($cachedResponse['headers'] as $key => $value) {
             $response->headers->set($key, $value);

--- a/app/Services/Entries/EntriesCacheService.php
+++ b/app/Services/Entries/EntriesCacheService.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace ec5\Services\Entries;
+
+use Closure;
+use Illuminate\Support\Facades\Cache;
+use Symfony\Component\HttpFoundation\Response;
+
+class EntriesCacheService
+{
+    public function isExportEntriesCacheEnabled(): bool
+    {
+        return (bool) config('cache.export_entries_cache_enabled');
+    }
+
+    public function getExportEntriesCacheTTL(): int
+    {
+        return (int) config('cache.export_entries_cache_ttl');
+    }
+
+    public function rememberExportEntriesResponse(
+        string $projectSlug,
+        string $fullUrl,
+        int $cacheTTL,
+        Closure $callback
+    ): Response {
+        $cacheKey = $this->getExportEntriesCacheKey($projectSlug, $fullUrl);
+        $cachedResponse = Cache::get($cacheKey);
+
+        if (is_array($cachedResponse)) {
+            $response = $this->getCachedExportEntriesResponse($cachedResponse);
+
+            if ($response) {
+                return $response;
+            }
+
+            Cache::forget($cacheKey);
+        }
+
+        $response = $callback();
+        Cache::put($cacheKey, $this->getCompressedResponseCachePayload($response), $cacheTTL);
+
+        return $response;
+    }
+
+    public function getExportEntriesCacheKey(string $projectSlug, string $fullUrl): string
+    {
+        return 'export_entries:' . hash('sha256', $projectSlug . '|' . $fullUrl);
+    }
+
+    private function getCompressedResponseCachePayload(Response $response): array
+    {
+        return [
+            'compressed' => true,
+            'content' => gzencode($response->getContent(), 3),
+            'status' => $response->getStatusCode(),
+            'headers' => $response->headers->all(),
+        ];
+    }
+
+    private function getCachedExportEntriesResponse(array $cachedResponse): ?Response
+    {
+        if (
+            !isset(
+                $cachedResponse['compressed'],
+                $cachedResponse['content'],
+                $cachedResponse['status'],
+                $cachedResponse['headers']
+            ) ||
+            $cachedResponse['compressed'] !== true
+        ) {
+            return null;
+        }
+
+        $content = gzdecode($cachedResponse['content']);
+
+        if ($content === false) {
+            return null;
+        }
+
+        $response = response($content, $cachedResponse['status']);
+
+        foreach ($cachedResponse['headers'] as $key => $value) {
+            $response->headers->set($key, $value);
+        }
+
+        return $response;
+    }
+}

--- a/config/cache.php
+++ b/config/cache.php
@@ -15,6 +15,10 @@ return [
 
     'default' => env('CACHE_DRIVER', 'file'),
 
+    'export_entries_cache_enabled' => env('EXPORT_ENTRIES_CACHE_ENABLED', false),
+
+    'export_entries_cache_ttl' => (int) env('EXPORT_ENTRIES_CACHE_TTL', 3600),
+
     /*
     |--------------------------------------------------------------------------
     | Cache Stores

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,6 +78,12 @@ Guard and middleware:
 Public media routes have an additional media limiter. The global external API limiter is IP-scoped, while project-scoped
 read/media limiters are keyed by project slug so rotating client IPs do not bypass project-level throttles.
 
+The documented entries export endpoint (`/api/export/entries/{project_slug}`) may use an application response cache, but
+that cache is reached only after the external route middleware has run. Private projects must pass
+`project.permissions.api`, including OAuth token validation and client-project authorization, before the controller can
+read from or write to the export entries cache. Public projects are intentionally not auth-restricted for this endpoint
+and are controlled by the configured export rate limiter.
+
 ## Media Caching
 
 **Photo** URLs support cache versioning via the `v` parameter.

--- a/tests/Http/Controllers/Api/Entries/View/External/ExportRoutes/EntriesExportCacheTest.php
+++ b/tests/Http/Controllers/Api/Entries/View/External/ExportRoutes/EntriesExportCacheTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests\Http\Controllers\Api\Entries\View\External\ExportRoutes;
+
+use ec5\Models\Entries\Entry;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Cache;
+use Tests\Http\Controllers\Api\Entries\View\ViewEntriesBaseControllerTest;
+use Throwable;
+
+class EntriesExportCacheTest extends ViewEntriesBaseControllerTest
+{
+    use DatabaseTransactions;
+
+    private string $endpoint = 'api/export/entries/';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+    }
+
+    public function tearDown(): void
+    {
+        Cache::flush();
+
+        parent::tearDown();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function test_entries_export_cache_hit_returns_same_response_for_same_url()
+    {
+        config()->set('cache.export_entries_cache_enabled', true);
+        config()->set('cache.export_entries_cache_ttl', 3600);
+
+        $formRef = $this->makeProjectPublicAndCreateParentEntry();
+        $url = $this->endpoint . $this->project->slug . '?form_ref=' . $formRef;
+
+        $firstResponse = $this->actingAs($this->user)->get($url);
+        $firstResponse->assertStatus(200);
+        $this->assertEntryCount($firstResponse->getContent(), 1);
+
+        $this->createParentEntry($formRef);
+        $this->assertCount(2, Entry::where('project_id', $this->project->id)->get());
+
+        $secondResponse = $this->actingAs($this->user)->get($url);
+        $secondResponse->assertStatus(200);
+
+        $this->assertSame($firstResponse->getContent(), $secondResponse->getContent());
+        $this->assertEntryCount($secondResponse->getContent(), 1);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function test_entries_export_cache_disabled_returns_fresh_response()
+    {
+        config()->set('cache.export_entries_cache_enabled', false);
+        config()->set('cache.export_entries_cache_ttl', 3600);
+
+        $formRef = $this->makeProjectPublicAndCreateParentEntry();
+        $url = $this->endpoint . $this->project->slug . '?form_ref=' . $formRef;
+
+        $firstResponse = $this->actingAs($this->user)->get($url);
+        $firstResponse->assertStatus(200);
+        $this->assertEntryCount($firstResponse->getContent(), 1);
+
+        $this->createParentEntry($formRef);
+
+        $secondResponse = $this->actingAs($this->user)->get($url);
+        $secondResponse->assertStatus(200);
+
+        $this->assertNotSame($firstResponse->getContent(), $secondResponse->getContent());
+        $this->assertEntryCount($secondResponse->getContent(), 2);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function test_entries_export_cache_ttl_zero_bypasses_cache()
+    {
+        config()->set('cache.export_entries_cache_enabled', true);
+        config()->set('cache.export_entries_cache_ttl', 0);
+
+        $formRef = $this->makeProjectPublicAndCreateParentEntry();
+        $url = $this->endpoint . $this->project->slug . '?form_ref=' . $formRef;
+
+        $firstResponse = $this->actingAs($this->user)->get($url);
+        $firstResponse->assertStatus(200);
+        $this->assertEntryCount($firstResponse->getContent(), 1);
+
+        $this->createParentEntry($formRef);
+
+        $secondResponse = $this->actingAs($this->user)->get($url);
+        $secondResponse->assertStatus(200);
+
+        $this->assertNotSame($firstResponse->getContent(), $secondResponse->getContent());
+        $this->assertEntryCount($secondResponse->getContent(), 2);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function test_entries_export_cache_key_uses_full_query_string()
+    {
+        config()->set('cache.export_entries_cache_enabled', true);
+        config()->set('cache.export_entries_cache_ttl', 3600);
+
+        $formRef = $this->makeProjectPublicAndCreateParentEntry();
+        $this->createParentEntry($formRef);
+
+        $firstUrl = $this->endpoint . $this->project->slug
+            . '?form_ref=' . $formRef
+            . '&per_page=1&page=1';
+        $secondUrl = $this->endpoint . $this->project->slug
+            . '?form_ref=' . $formRef
+            . '&per_page=1&page=2';
+
+        $firstResponse = $this->actingAs($this->user)->get($firstUrl);
+        $firstResponse->assertStatus(200);
+        $this->assertEntryCount($firstResponse->getContent(), 1);
+
+        $secondResponse = $this->actingAs($this->user)->get($secondUrl);
+        $secondResponse->assertStatus(200);
+        $this->assertEntryCount($secondResponse->getContent(), 1);
+
+        $this->assertNotSame($firstResponse->getContent(), $secondResponse->getContent());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function makeProjectPublicAndCreateParentEntry(): string
+    {
+        $this->project->access = config('epicollect.strings.project_access.public');
+        $this->project->save();
+
+        $formRef = array_get($this->projectDefinition, 'data.project.forms.0.ref');
+        $this->createParentEntry($formRef);
+
+        return $formRef;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function createParentEntry(string $formRef): void
+    {
+        $entryPayload = $this->entryGenerator->createParentEntryPayload($formRef);
+        $entryRowBundle = $this->entryGenerator->createParentEntryRow(
+            $this->user,
+            $this->project,
+            $this->role,
+            $this->projectDefinition,
+            $entryPayload
+        );
+
+        $this->assertEntryRowAgainstPayload(
+            $entryRowBundle,
+            $entryPayload
+        );
+    }
+
+    private function assertEntryCount(string $content, int $count): void
+    {
+        $json = json_decode($content, true);
+
+        $this->assertCount($count, $json['data']['entries']);
+    }
+}

--- a/tests/Http/Controllers/Api/Entries/View/External/ExportRoutes/EntriesExportCacheTest.php
+++ b/tests/Http/Controllers/Api/Entries/View/External/ExportRoutes/EntriesExportCacheTest.php
@@ -45,7 +45,7 @@ class EntriesExportCacheTest extends ViewEntriesBaseControllerTest
         $firstResponse->assertHeader('X-Epicollect-Cache', 'miss');
         $firstResponse->assertHeader('X-Epicollect-Cache-Ttl', '123');
         $this->assertEntryCount($firstResponse->getContent(), 1);
-        $this->assertCompressedCachePayload($url, $firstResponse->getContent());
+        $this->assertCachePayload($url, $firstResponse->getContent());
 
         $this->createParentEntry($formRef);
         $this->assertCount(2, Entry::where('project_id', $this->project->id)->get());
@@ -177,7 +177,7 @@ class EntriesExportCacheTest extends ViewEntriesBaseControllerTest
         $this->assertCount($count, $json['data']['entries']);
     }
 
-    private function assertCompressedCachePayload(string $url, string $expectedContent): void
+    private function assertCachePayload(string $url, string $expectedContent): void
     {
         $fullUrl = 'http://localhost/' . $url;
         $cacheKey = app(EntriesCacheService::class)->getExportEntriesCacheKey(
@@ -187,8 +187,8 @@ class EntriesExportCacheTest extends ViewEntriesBaseControllerTest
         $cachedResponse = Cache::get($cacheKey);
 
         $this->assertIsArray($cachedResponse);
-        $this->assertTrue($cachedResponse['compressed']);
-        $this->assertSame($expectedContent, gzdecode($cachedResponse['content']));
+        $this->assertArrayNotHasKey('compressed', $cachedResponse);
+        $this->assertSame($expectedContent, $cachedResponse['content']);
         $this->assertSame(200, $cachedResponse['status']);
     }
 }

--- a/tests/Http/Controllers/Api/Entries/View/External/ExportRoutes/EntriesExportCacheTest.php
+++ b/tests/Http/Controllers/Api/Entries/View/External/ExportRoutes/EntriesExportCacheTest.php
@@ -72,6 +72,8 @@ class EntriesExportCacheTest extends ViewEntriesBaseControllerTest
 
         $firstResponse = $this->actingAs($this->user)->get($url);
         $firstResponse->assertStatus(200);
+        $firstResponse->assertHeaderMissing('X-Epicollect-Cache');
+
         $this->assertEntryCount($firstResponse->getContent(), 1);
 
         $this->createParentEntry($formRef);

--- a/tests/Http/Controllers/Api/Entries/View/External/ExportRoutes/EntriesExportCacheTest.php
+++ b/tests/Http/Controllers/Api/Entries/View/External/ExportRoutes/EntriesExportCacheTest.php
@@ -35,13 +35,15 @@ class EntriesExportCacheTest extends ViewEntriesBaseControllerTest
     public function test_entries_export_cache_hit_returns_same_response_for_same_url()
     {
         config()->set('cache.export_entries_cache_enabled', true);
-        config()->set('cache.export_entries_cache_ttl', 3600);
+        config()->set('cache.export_entries_cache_ttl', 123);
 
         $formRef = $this->makeProjectPublicAndCreateParentEntry();
         $url = $this->endpoint . $this->project->slug . '?form_ref=' . $formRef;
 
         $firstResponse = $this->actingAs($this->user)->get($url);
         $firstResponse->assertStatus(200);
+        $firstResponse->assertHeader('X-Epicollect-Cache', 'miss');
+        $firstResponse->assertHeader('X-Epicollect-Cache-Ttl', '123');
         $this->assertEntryCount($firstResponse->getContent(), 1);
         $this->assertCompressedCachePayload($url, $firstResponse->getContent());
 
@@ -50,6 +52,8 @@ class EntriesExportCacheTest extends ViewEntriesBaseControllerTest
 
         $secondResponse = $this->actingAs($this->user)->get($url);
         $secondResponse->assertStatus(200);
+        $secondResponse->assertHeader('X-Epicollect-Cache', 'hit');
+        $secondResponse->assertHeader('X-Epicollect-Cache-Ttl', '123');
 
         $this->assertSame($firstResponse->getContent(), $secondResponse->getContent());
         $this->assertEntryCount($secondResponse->getContent(), 1);

--- a/tests/Http/Controllers/Api/Entries/View/External/ExportRoutes/EntriesExportCacheTest.php
+++ b/tests/Http/Controllers/Api/Entries/View/External/ExportRoutes/EntriesExportCacheTest.php
@@ -188,7 +188,8 @@ class EntriesExportCacheTest extends ViewEntriesBaseControllerTest
 
         $this->assertIsArray($cachedResponse);
         $this->assertArrayNotHasKey('compressed', $cachedResponse);
-        $this->assertArrayNotHasKey('headers', $cachedResponse);
+        $this->assertArrayHasKey('headers', $cachedResponse);
+        $this->assertArrayNotHasKey('content_type', $cachedResponse);
         $this->assertSame($expectedContent, $cachedResponse['content']);
         $this->assertSame(200, $cachedResponse['status']);
     }

--- a/tests/Http/Controllers/Api/Entries/View/External/ExportRoutes/EntriesExportCacheTest.php
+++ b/tests/Http/Controllers/Api/Entries/View/External/ExportRoutes/EntriesExportCacheTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Http\Controllers\Api\Entries\View\External\ExportRoutes;
 
 use ec5\Models\Entries\Entry;
+use ec5\Services\Entries\EntriesCacheService;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Cache;
 use Tests\Http\Controllers\Api\Entries\View\ViewEntriesBaseControllerTest;
@@ -42,6 +43,7 @@ class EntriesExportCacheTest extends ViewEntriesBaseControllerTest
         $firstResponse = $this->actingAs($this->user)->get($url);
         $firstResponse->assertStatus(200);
         $this->assertEntryCount($firstResponse->getContent(), 1);
+        $this->assertCompressedCachePayload($url, $firstResponse->getContent());
 
         $this->createParentEntry($formRef);
         $this->assertCount(2, Entry::where('project_id', $this->project->id)->get());
@@ -169,5 +171,20 @@ class EntriesExportCacheTest extends ViewEntriesBaseControllerTest
         $json = json_decode($content, true);
 
         $this->assertCount($count, $json['data']['entries']);
+    }
+
+    private function assertCompressedCachePayload(string $url, string $expectedContent): void
+    {
+        $fullUrl = 'http://localhost/' . $url;
+        $cacheKey = app(EntriesCacheService::class)->getExportEntriesCacheKey(
+            $this->project->slug,
+            $fullUrl
+        );
+        $cachedResponse = Cache::get($cacheKey);
+
+        $this->assertIsArray($cachedResponse);
+        $this->assertTrue($cachedResponse['compressed']);
+        $this->assertSame($expectedContent, gzdecode($cachedResponse['content']));
+        $this->assertSame(200, $cachedResponse['status']);
     }
 }

--- a/tests/Http/Controllers/Api/Entries/View/External/ExportRoutes/EntriesExportCacheTest.php
+++ b/tests/Http/Controllers/Api/Entries/View/External/ExportRoutes/EntriesExportCacheTest.php
@@ -188,6 +188,7 @@ class EntriesExportCacheTest extends ViewEntriesBaseControllerTest
 
         $this->assertIsArray($cachedResponse);
         $this->assertArrayNotHasKey('compressed', $cachedResponse);
+        $this->assertArrayNotHasKey('headers', $cachedResponse);
         $this->assertSame($expectedContent, $cachedResponse['content']);
         $this->assertSame(200, $cachedResponse['status']);
     }

--- a/tests/Services/Entries/EntriesCacheServiceTest.php
+++ b/tests/Services/Entries/EntriesCacheServiceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Services\Entries;
+
+use ec5\Services\Entries\EntriesCacheService;
+use Illuminate\Support\Facades\Cache;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Tests\TestCase;
+
+class EntriesCacheServiceTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+    }
+
+    public function tearDown(): void
+    {
+        Cache::flush();
+
+        parent::tearDown();
+    }
+
+    public function test_streamed_export_response_is_not_cached(): void
+    {
+        $service = app(EntriesCacheService::class);
+        $projectSlug = 'test-project';
+        $fullUrl = 'http://localhost/api/export/entries/test-project?format=csv';
+        $cacheTTL = 123;
+        $cacheKey = $service->getExportEntriesCacheKey($projectSlug, $fullUrl);
+
+        $response = $service->rememberExportEntriesResponse(
+            $projectSlug,
+            $fullUrl,
+            $cacheTTL,
+            function () {
+                return new StreamedResponse(function () {
+                    echo 'csv';
+                });
+            }
+        );
+
+        $this->assertNull(Cache::get($cacheKey));
+        $this->assertSame('bypass', $response->headers->get('X-Epicollect-Cache'));
+        $this->assertSame('123', $response->headers->get('X-Epicollect-Cache-Ttl'));
+    }
+
+    public function test_non_successful_export_response_is_not_cached(): void
+    {
+        $service = app(EntriesCacheService::class);
+        $projectSlug = 'test-project';
+        $fullUrl = 'http://localhost/api/export/entries/test-project?format=json';
+        $cacheTTL = 123;
+        $cacheKey = $service->getExportEntriesCacheKey($projectSlug, $fullUrl);
+
+        $response = $service->rememberExportEntriesResponse(
+            $projectSlug,
+            $fullUrl,
+            $cacheTTL,
+            function () {
+                return new Response('error', 400);
+            }
+        );
+
+        $this->assertNull(Cache::get($cacheKey));
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('bypass', $response->headers->get('X-Epicollect-Cache'));
+        $this->assertSame('123', $response->headers->get('X-Epicollect-Cache-Ttl'));
+    }
+}

--- a/tests/Services/Entries/EntriesCacheServiceTest.php
+++ b/tests/Services/Entries/EntriesCacheServiceTest.php
@@ -111,7 +111,8 @@ class EntriesCacheServiceTest extends TestCase
         $this->assertSame(200, Cache::get($cacheKey)['status']);
         $this->assertSame(
             'application/vnd.api+json; charset=utf-8',
-            Cache::get($cacheKey)['content_type']
+            Cache::get($cacheKey)['headers']['Content-Type'][0]
         );
+        $this->assertArrayNotHasKey('content_type', Cache::get($cacheKey));
     }
 }

--- a/tests/Services/Entries/EntriesCacheServiceTest.php
+++ b/tests/Services/Entries/EntriesCacheServiceTest.php
@@ -70,4 +70,48 @@ class EntriesCacheServiceTest extends TestCase
         $this->assertSame('bypass', $response->headers->get('X-Epicollect-Cache'));
         $this->assertSame('123', $response->headers->get('X-Epicollect-Cache-Ttl'));
     }
+
+    public function test_cached_response_preserves_content_type(): void
+    {
+        $service = app(EntriesCacheService::class);
+        $projectSlug = 'test-project';
+        $fullUrl = 'http://localhost/api/export/entries/test-project?format=json';
+        $cacheTTL = 123;
+        $cacheKey = $service->getExportEntriesCacheKey($projectSlug, $fullUrl);
+
+        $firstResponse = $service->rememberExportEntriesResponse(
+            $projectSlug,
+            $fullUrl,
+            $cacheTTL,
+            function () {
+                return response()->json(['ok' => true], 200, [
+                    'Content-Type' => 'application/vnd.api+json; charset=utf-8',
+                ]);
+            }
+        );
+
+        $secondResponse = $service->rememberExportEntriesResponse(
+            $projectSlug,
+            $fullUrl,
+            $cacheTTL,
+            function () {
+                return response()->json(['ok' => false]);
+            }
+        );
+
+        $this->assertSame(
+            'application/vnd.api+json; charset=utf-8',
+            $firstResponse->headers->get('Content-Type')
+        );
+        $this->assertSame(
+            'application/vnd.api+json; charset=utf-8',
+            $secondResponse->headers->get('Content-Type')
+        );
+        $this->assertSame($firstResponse->getContent(), $secondResponse->getContent());
+        $this->assertSame(200, Cache::get($cacheKey)['status']);
+        $this->assertSame(
+            'application/vnd.api+json; charset=utf-8',
+            Cache::get($cacheKey)['content_type']
+        );
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional caching for entry exports: identical export requests can be served from cache to improve performance. Cache is disabled by default and TTL is configurable (default 3600s).

* **Chores**
  * Export-related cache cleanup schedule changed to run daily.

* **Tests**
  * Added tests validating export caching behavior, TTL handling, cache-key correctness, and cache bypass scenarios.

* **Documentation**
  * Clarified export endpoint caching, auth and rate-limit behavior in architecture docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/epicollect5/epicollect5-server/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->