### PR TITLE
feat: add FFmpeg compression configuration for audio/video uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ CACHE_DRIVER=file
 # Media cache duration in hours for unversioned photo URLs. Defaults to 24.
 MEDIA_CACHE_CONTROL_HOURS=24
 
+# Enable FFmpeg compression for audio/video uploads. Disabled by default.
+AUDIO_VIDEO_FFMPEG_COMPRESSION_ENABLED=false
+
 # Static assets: "local" uses APP_URL, "cdn" uses STATIC_ASSETS_CDN_ENDPOINT.
 STATIC_ASSETS_DRIVER=local
 STATIC_ASSETS_CDN_ENDPOINT=

--- a/app/Services/Media/AudioVideoSaverService.php
+++ b/app/Services/Media/AudioVideoSaverService.php
@@ -109,14 +109,17 @@ class AudioVideoSaverService
             }
 
             if ($fileSaved) {
-                //compress the file if it is a video or audio (.wav currently skipped for legacy reasons)
-                if ($disk === 'video' || $disk === 'audio') {
-                    $compressionService = app(AudioVideoCompressionService::class);
-                    $compressionSuccess = $compressionService->compress($disk, $targetPath, $disk);
+                //Check if ffmpeg compression is enabled
+                if (config('epicollect.media.audio_video_ffmpeg_compression_enabled')) {
+                    //compress the file if it is a video or audio (.wav currently skipped for legacy reasons)
+                    if ($disk === 'video' || $disk === 'audio') {
+                        $compressionService = app(AudioVideoCompressionService::class);
+                        $compressionSuccess = $compressionService->compress($disk, $targetPath, $disk);
 
-                    if (!$compressionSuccess) {
-                        Log::warning("Compression failed for $targetPath");
-                        // Optionally return false to force user re-upload
+                        if (!$compressionSuccess) {
+                            Log::warning("Compression failed for $targetPath");
+                            // Optionally return false to force user re-upload
+                        }
                     }
                 }
 

--- a/config/epicollect/media.php
+++ b/config/epicollect/media.php
@@ -79,5 +79,6 @@ return [
         'always' => 'public, max-age=31536000, immutable',
         'hours' => (int) env('MEDIA_CACHE_CONTROL_HOURS', 24),
         'never' => 'no-store'
-    ]
+    ],
+    'audio_video_ffmpeg_compression_enabled' => (bool) env('AUDIO_VIDEO_FFMPEG_COMPRESSION_ENABLED', false)
 ];

--- a/tests/Services/Media/AudioVideoSaverServiceLocalTest.php
+++ b/tests/Services/Media/AudioVideoSaverServiceLocalTest.php
@@ -4,10 +4,12 @@ namespace Tests\Services\Media;
 
 use ec5\Models\Project\Project;
 use ec5\Models\Project\ProjectStats;
+use ec5\Services\Media\AudioVideoCompressionService;
 use ec5\Services\Media\AudioVideoSaverService;
 use Exception;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Http\UploadedFile;
+use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Ramsey\Uuid\Uuid;
 use Storage;
@@ -102,5 +104,67 @@ class AudioVideoSaverServiceLocalTest extends TestCase
         $this->assertEquals(1, $projectStats->audio_files);
         $this->assertEquals($fileBytes, $projectStats->total_bytes);
         $this->assertEquals(1, $projectStats->total_files);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function test_compression_is_not_called_when_flag_is_false_local()
+    {
+        config(['epicollect.media.audio_video_ffmpeg_compression_enabled' => false]);
+
+        $project = factory(Project::class)->create();
+        factory(ProjectStats::class)->create([
+            'project_id' => $project->id,
+        ]);
+
+        $fileName = Uuid::uuid4()->toString() . '_' . time() . '.mp4';
+        $disk = 'audio';
+        $fileSizeKB = 2048;
+        $fileBytes = $fileSizeKB * 1024;
+
+        $file = UploadedFile::fake()
+            ->create($fileName, $fileSizeKB, 'audio/mp4');
+
+        $compressionMock = Mockery::mock(AudioVideoCompressionService::class);
+        $compressionMock->shouldNotReceive('compress');
+        $this->app->instance(AudioVideoCompressionService::class, $compressionMock);
+
+        Storage::shouldReceive('disk')
+            ->with($disk)
+            ->zeroOrMoreTimes()
+            ->andReturnSelf();
+
+        Storage::shouldReceive('exists')
+            ->with($project->ref)
+            ->once()
+            ->andReturn(false);
+
+        Storage::shouldReceive('makeDirectory')
+            ->with($project->ref)
+            ->once()
+            ->andReturn(true);
+
+        $targetPath = $project->ref . '/' . $fileName;
+        Storage::shouldReceive('put')
+            ->once()
+            ->withArgs(function ($path, $stream) use ($targetPath) {
+                return $path === $targetPath && is_resource($stream);
+            })
+            ->andReturn(true);
+
+        Storage::shouldReceive('size')
+            ->with($targetPath)
+            ->andReturn($fileBytes);
+
+        $result = AudioVideoSaverService::saveFile(
+            $project->ref,
+            $project->id,
+            $file,
+            $fileName,
+            $disk,
+            false
+        );
+        $this->assertTrue($result);
     }
 }

--- a/tests/Services/Media/AudioVideoSaverServiceLocalTest.php
+++ b/tests/Services/Media/AudioVideoSaverServiceLocalTest.php
@@ -167,4 +167,69 @@ class AudioVideoSaverServiceLocalTest extends TestCase
         );
         $this->assertTrue($result);
     }
+
+    /**
+     * @throws Exception
+     */
+    public function test_compression_is_called_when_flag_is_true_local()
+    {
+        config(['epicollect.media.audio_video_ffmpeg_compression_enabled' => true]);
+
+        $project = factory(Project::class)->create();
+        factory(ProjectStats::class)->create([
+            'project_id' => $project->id,
+        ]);
+
+        $fileName = Uuid::uuid4()->toString() . '_' . time() . '.mp4';
+        $disk = 'audio';
+        $fileSizeKB = 2048;
+        $fileBytes = $fileSizeKB * 1024;
+        $targetPath = $project->ref . '/' . $fileName;
+
+        $file = UploadedFile::fake()
+            ->create($fileName, $fileSizeKB, 'audio/mp4');
+
+        $compressionMock = Mockery::mock(AudioVideoCompressionService::class);
+        $compressionMock->shouldReceive('compress')
+            ->once()
+            ->with($disk, $targetPath, $disk)
+            ->andReturn(true);
+        app()->instance(AudioVideoCompressionService::class, $compressionMock);
+
+        Storage::shouldReceive('disk')
+            ->with($disk)
+            ->zeroOrMoreTimes()
+            ->andReturnSelf();
+
+        Storage::shouldReceive('exists')
+            ->with($project->ref)
+            ->once()
+            ->andReturn(false);
+
+        Storage::shouldReceive('makeDirectory')
+            ->with($project->ref)
+            ->once()
+            ->andReturn(true);
+
+        Storage::shouldReceive('put')
+            ->once()
+            ->withArgs(function ($path, $stream) use ($targetPath) {
+                return $path === $targetPath && is_resource($stream);
+            })
+            ->andReturn(true);
+
+        Storage::shouldReceive('size')
+            ->with($targetPath)
+            ->andReturn($fileBytes);
+
+        $result = AudioVideoSaverService::saveFile(
+            $project->ref,
+            $project->id,
+            $file,
+            $fileName,
+            $disk,
+            false
+        );
+        $this->assertTrue($result);
+    }
 }

--- a/tests/Services/Media/AudioVideoSaverServiceS3Test.php
+++ b/tests/Services/Media/AudioVideoSaverServiceS3Test.php
@@ -241,11 +241,58 @@ class AudioVideoSaverServiceS3Test extends TestCase
         Storage::shouldReceive('size')
             ->andReturn($fileBytes);
 
-        Storage::shouldReceive('move')
+        Storage::shouldReceive('put')
             ->andReturn(true);
 
-        Storage::shouldReceive('delete')
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, 'fake audio content');
+        rewind($stream);
+
+        Storage::shouldReceive('readStream')
+            ->andReturn($stream);
+
+        $result = AudioVideoSaverService::saveFile(
+            $project->ref,
+            $project->id,
+            ['path' => $filePath],
+            $fileName,
+            $disk,
+            true
+        );
+
+        $this->assertTrue($result);
+    }
+
+    public function test_compression_is_called_when_flag_is_true_s3()
+    {
+        config(['epicollect.media.audio_video_ffmpeg_compression_enabled' => true]);
+
+        $project = factory(Project::class)->create();
+        factory(ProjectStats::class)->create([
+            'project_id' => $project->id,
+        ]);
+
+        $fileName = Uuid::uuid4()->toString() . '_' . time() . '.mp4';
+        $disk = 'audio';
+        $filePath = 'temp/' . $fileName;
+        $fileBytes = 21;
+        $targetPath = $project->ref . '/' . $fileName;
+
+        $compressionMock = Mockery::mock(AudioVideoCompressionService::class);
+        $compressionMock->shouldReceive('compress')
+            ->once()
+            ->with($disk, $targetPath, $disk)
             ->andReturn(true);
+        $this->app->instance(AudioVideoCompressionService::class, $compressionMock);
+
+        Storage::shouldReceive('disk')
+            ->andReturnSelf();
+
+        Storage::shouldReceive('exists')
+            ->andReturn(true);
+
+        Storage::shouldReceive('size')
+            ->andReturn($fileBytes);
 
         Storage::shouldReceive('put')
             ->andReturn(true);

--- a/tests/Services/Media/AudioVideoSaverServiceS3Test.php
+++ b/tests/Services/Media/AudioVideoSaverServiceS3Test.php
@@ -7,10 +7,12 @@ use Aws\S3\Exception\S3Exception;
 use ec5\Libraries\Utilities\Generators;
 use ec5\Models\Project\Project;
 use ec5\Models\Project\ProjectStats;
+use ec5\Services\Media\AudioVideoCompressionService;
 use ec5\Services\Media\AudioVideoSaverService;
 use Exception;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Ramsey\Uuid\Uuid;
 use Storage;
@@ -212,6 +214,61 @@ class AudioVideoSaverServiceS3Test extends TestCase
     /**
      * @throws Exception
      */
+    public function test_compression_is_not_called_when_flag_is_false_s3()
+    {
+        config(['epicollect.media.audio_video_ffmpeg_compression_enabled' => false]);
+
+        $project = factory(Project::class)->create();
+        factory(ProjectStats::class)->create([
+            'project_id' => $project->id,
+        ]);
+
+        $fileName = Uuid::uuid4()->toString() . '_' . time() . '.mp4';
+        $disk = 'audio';
+        $filePath = 'temp/' . $fileName;
+        $fileBytes = 21;
+
+        $compressionMock = Mockery::mock(AudioVideoCompressionService::class);
+        $compressionMock->shouldNotReceive('compress');
+        $this->app->instance(AudioVideoCompressionService::class, $compressionMock);
+
+        Storage::shouldReceive('disk')
+            ->andReturnSelf();
+
+        Storage::shouldReceive('exists')
+            ->andReturn(true);
+
+        Storage::shouldReceive('size')
+            ->andReturn($fileBytes);
+
+        Storage::shouldReceive('move')
+            ->andReturn(true);
+
+        Storage::shouldReceive('delete')
+            ->andReturn(true);
+
+        Storage::shouldReceive('put')
+            ->andReturn(true);
+
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, 'fake audio content');
+        rewind($stream);
+
+        Storage::shouldReceive('readStream')
+            ->andReturn($stream);
+
+        $result = AudioVideoSaverService::saveFile(
+            $project->ref,
+            $project->id,
+            ['path' => $filePath],
+            $fileName,
+            $disk,
+            true
+        );
+
+        $this->assertTrue($result);
+    }
+
     public function test_service_handles_s3_put_returns_false()
     {
         $projectRef = Generators::projectRef();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio and video uploads now support optional FFmpeg compression through a configuration flag, allowing administrators to control this behavior. Compression is disabled by default.

* **Tests**
  * Added tests to verify compression behavior when the feature flag is disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/epicollect5/epicollect5-server/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->