### PR TITLE
fix: update placeholder caching logic to prevent indefinite caching

### DIFF
--- a/app/Providers/Macros/Response/ToEntryThumbLocalMacro.php
+++ b/app/Providers/Macros/Response/ToEntryThumbLocalMacro.php
@@ -59,7 +59,7 @@ class ToEntryThumbLocalMacro extends ServiceProvider
                     }
                     $response = Response::make($file);
                     $response->header('Content-Type', config('epicollect.media.content_type.photo'));
-                    $response->header('Cache-Control', config('epicollect.media.cache_control.always'));
+                    $response->header('Cache-Control', config('epicollect.media.cache_control.never'));
                     return $response;
                 } catch (Throwable $e) {
                     Log::error('Cannot generate thumbnail', ['exception' => $e]);
@@ -70,7 +70,7 @@ class ToEntryThumbLocalMacro extends ServiceProvider
             $file = Storage::disk('public')->get($photoPlaceholderFilename);
             $response = Response::make($file);
             $response->header('Content-Type', config('epicollect.media.content_type.photo'));
-            $response->header('Cache-Control', config('epicollect.media.cache_control.always'));
+            $response->header('Cache-Control', config('epicollect.media.cache_control.never'));
             return $response;
         });
     }

--- a/app/Providers/Macros/Response/ToEntryThumbS3Macro.php
+++ b/app/Providers/Macros/Response/ToEntryThumbS3Macro.php
@@ -67,7 +67,7 @@ class ToEntryThumbS3Macro extends ServiceProvider
                     }
                     $response = Response::make($file);
                     $response->header('Content-Type', config('epicollect.media.content_type.photo'));
-                    $response->header('Cache-Control', config('epicollect.media.cache_control.always'));
+                    $response->header('Cache-Control', config('epicollect.media.cache_control.never'));
                     return $response;
                 } catch (Throwable $e) {
                     Log::error('Cannot generate S3 thumbnail', ['exception' => $e]);
@@ -78,7 +78,7 @@ class ToEntryThumbS3Macro extends ServiceProvider
             $file = Storage::disk('public')->get($photoPlaceholderFilename);
             $response = Response::make($file);
             $response->header('Content-Type', config('epicollect.media.content_type.photo'));
-            $response->header('Cache-Control', config('epicollect.media.cache_control.always'));
+            $response->header('Cache-Control', config('epicollect.media.cache_control.never'));
             return $response;
         });
     }

--- a/app/Providers/Macros/Response/ToProjectMobileLogoLocalMacro.php
+++ b/app/Providers/Macros/Response/ToProjectMobileLogoLocalMacro.php
@@ -72,7 +72,7 @@ class ToProjectMobileLogoLocalMacro extends ServiceProvider
 
             return response($resizedData, 200, [
                 'Content-Type' => config('epicollect.media.content_type.photo'),
-                'Cache-Control' => config('epicollect.media.cache_control.always'),
+                'Cache-Control' => config('epicollect.media.cache_control.never'),
             ]);
         });
     }

--- a/app/Providers/Macros/Response/ToProjectMobileLogoS3Macro.php
+++ b/app/Providers/Macros/Response/ToProjectMobileLogoS3Macro.php
@@ -79,7 +79,7 @@ class ToProjectMobileLogoS3Macro extends ServiceProvider
 
             return response($thumbnailData, 200, [
                 'Content-Type' => config('epicollect.media.content_type.photo'),
-                'Cache-Control' => config('epicollect.media.cache_control.always'),
+                'Cache-Control' => config('epicollect.media.cache_control.never'),
             ]);
         });
     }

--- a/app/Services/Media/MediaService.php
+++ b/app/Services/Media/MediaService.php
@@ -226,7 +226,7 @@ class MediaService
 
             return Response::make($file, 200, [
                 'Content-Type' => $contentType,
-                'Cache-Control' => config('epicollect.media.cache_control.always')
+                'Cache-Control' => config('epicollect.media.cache_control.never')
             ]);
         }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,6 +151,14 @@ for the replacement case.
 This means the placeholder `no-store` fix alone covers the real gap: the period between entry creation (which sets
 `uploaded_at`) and a deferred photo upload (which does not change `uploaded_at`).
 
+**Note on the `private` directive:** Placeholder responses served through the internal API
+(`api/internal/media/*`) may show `Cache-Control: no-store, private` in the browser. The `private`
+directive is automatically appended by Symfony's `Response` class when the
+`AddQueuedCookiesToResponse` middleware attaches session or XSRF-TOKEN cookies to the response.
+It does not affect caching behaviour — `no-store` already prevents the browser from storing the
+response. The external API (`api/media/*`) has no cookie middleware, so the `private` directive
+does not appear on those responses.
+
 ### Rate Limiters
 
 Defined in `app/Providers/RateLimiterServiceProvider.php`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,6 +129,28 @@ Audio and video cache behavior is different.
   clients
   should not store or reuse the signed URL after its TTL.
 
+### Placeholder caching (photo)
+
+When a requested media file does not exist (not yet uploaded, or deleted), the server serves a placeholder image.
+
+Historically, placeholders were served with the same `Cache-Control: public, max-age=31536000, immutable` header as real
+photos. This caused a problem: if a project was browsed before a photo finished uploading, the placeholder was cached
+permanently by the browser. When the real photo was uploaded later, the URL (same `name` + same `v`) was unchanged, so
+the browser served the cached placeholder indefinitely.
+
+The fix: placeholder responses now use `Cache-Control: no-store` (config key `cache_control.never` in
+`config/epicollect/media.php`). This ensures the browser never caches a placeholder — it must re-fetch every time. Once
+the real file exists, the server returns the photo with the standard `immutable` cache header, and the browser caches
+that from that point forward.
+
+The `v` parameter in media URLs is derived from the entry's `uploaded_at` column. When a photo is replaced through an
+entry edit, `CreateEntryService::create()` always sets `uploaded_at` to the current timestamp, so `v` changes and the
+cache is naturally busted. No additional mechanism (e.g. file `lastModified()` or a `media_version` column) is needed
+for the replacement case.
+
+This means the placeholder `no-store` fix alone covers the real gap: the period between entry creation (which sets
+`uploaded_at`) and a deferred photo upload (which does not change `uploaded_at`).
+
 ### Rate Limiters
 
 Defined in `app/Providers/RateLimiterServiceProvider.php`.
@@ -357,7 +379,8 @@ rather than `project_stats`.
 
 `project_stats` entry counters are refreshed on demand when callers ask for project-level totals or metadata that
 includes those totals. Examples include the dataviewer shell, formbuilder, project show/export metadata, and the
-internal entry counters endpoint. Delete paths also refresh project stats after entries are removed so deletion decisions
+internal entry counters endpoint. Delete paths also refresh project stats after entries are removed so deletion
+decisions
 and follow-up UI state do not rely on stale totals.
 
 The documented entries export endpoint, `api/export/entries`, is paginated. Refresh the cached counters at the first

--- a/tests/Http/Controllers/Api/Project/MediaControllerCacheHeadersTest.php
+++ b/tests/Http/Controllers/Api/Project/MediaControllerCacheHeadersTest.php
@@ -310,4 +310,40 @@ class MediaControllerCacheHeadersTest extends TestCase
         $this->assertStringContainsString('immutable', $cacheControl);
         $this->assertStringContainsString('max-age=31536000', $cacheControl);
     }
+
+    #[DataProvider('multipleRunProvider')]
+    public function test_entry_original_placeholder_has_no_cache()
+    {
+        $response = $this->get('api/internal/media/' . $this->project->slug . '?type=photo&name=non-existent.jpg&format=entry_original');
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', config('epicollect.media.content_type.photo'));
+        $cacheControl = $response->headers->get('Cache-Control');
+        $this->assertStringContainsString('no-store', $cacheControl);
+        $this->assertStringNotContainsString('max-age', $cacheControl);
+    }
+
+    #[DataProvider('multipleRunProvider')]
+    public function test_entry_thumb_placeholder_has_no_cache()
+    {
+        $response = $this->get('api/internal/media/' . $this->project->slug . '?type=photo&name=non-existent.jpg&format=entry_thumb');
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', config('epicollect.media.content_type.photo'));
+        $cacheControl = $response->headers->get('Cache-Control');
+        $this->assertStringContainsString('no-store', $cacheControl);
+        $this->assertStringNotContainsString('max-age', $cacheControl);
+    }
+
+    #[DataProvider('multipleRunProvider')]
+    public function test_project_mobile_logo_placeholder_has_no_cache()
+    {
+        $response = $this->get('api/internal/media/' . $this->project->slug . '?type=photo&name=non-existent.jpg&format=project_mobile_logo');
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', config('epicollect.media.content_type.photo'));
+        $cacheControl = $response->headers->get('Cache-Control');
+        $this->assertStringContainsString('no-store', $cacheControl);
+        $this->assertStringNotContainsString('max-age', $cacheControl);
+    }
 }

--- a/tests/Http/Controllers/Api/Project/MediaControllerLocalTest.php
+++ b/tests/Http/Controllers/Api/Project/MediaControllerLocalTest.php
@@ -375,6 +375,9 @@ class MediaControllerLocalTest extends TestCase
         $this->assertEquals($imageSizeInBytes, config('epicollect.media.photo_not_synced_placeholder.size_in_bytes'));
 
         $response->assertHeader('Content-Type', config('epicollect.media.content_type.photo'));
+        $cacheControl = $response->headers->get('Cache-Control');
+        $this->assertStringContainsString('no-store', $cacheControl);
+        $this->assertStringNotContainsString('max-age', $cacheControl);
     }
 
     #[DataProvider('multipleRunProvider')] public function test_project_thumb_logo_is_returned()

--- a/tests/Services/Media/MediaServiceTest.php
+++ b/tests/Services/Media/MediaServiceTest.php
@@ -60,22 +60,6 @@ class MediaServiceTest extends TestCase
         $this->assertStringNotContainsString('immutable', $cacheControl);
     }
 
-    public function test_it_serves_generic_placeholder_with_no_cache()
-    {
-        $response = $this->mediaService->serveLocalFile(
-            config('epicollect.strings.inputs_type.photo'),
-            'entry_original',
-            $this->project->ref,
-            null,
-        );
-
-        $this->assertEquals(200, $response->status());
-        $cacheControl = $response->headers->get('Cache-Control');
-        $this->assertStringContainsString('no-store', $cacheControl);
-        $this->assertStringNotContainsString('max-age', $cacheControl);
-        $this->assertStringNotContainsString('immutable', $cacheControl);
-    }
-
     public function test_it_serves_photo_not_synced_placeholder_with_no_cache()
     {
         $response = $this->mediaService->serveLocalFile(

--- a/tests/Services/Media/MediaServiceTest.php
+++ b/tests/Services/Media/MediaServiceTest.php
@@ -54,6 +54,42 @@ class MediaServiceTest extends TestCase
 
         $this->assertEquals(200, $response->status());
         $this->assertTrue($response->headers->has('Content-Type'));
+        $cacheControl = $response->headers->get('Cache-Control');
+        $this->assertStringContainsString('no-store', $cacheControl);
+        $this->assertStringNotContainsString('max-age', $cacheControl);
+        $this->assertStringNotContainsString('immutable', $cacheControl);
+    }
+
+    public function test_it_serves_generic_placeholder_with_no_cache()
+    {
+        $response = $this->mediaService->serveLocalFile(
+            config('epicollect.strings.inputs_type.photo'),
+            'entry_original',
+            $this->project->ref,
+            null,
+        );
+
+        $this->assertEquals(200, $response->status());
+        $cacheControl = $response->headers->get('Cache-Control');
+        $this->assertStringContainsString('no-store', $cacheControl);
+        $this->assertStringNotContainsString('max-age', $cacheControl);
+        $this->assertStringNotContainsString('immutable', $cacheControl);
+    }
+
+    public function test_it_serves_photo_not_synced_placeholder_with_no_cache()
+    {
+        $response = $this->mediaService->serveLocalFile(
+            config('epicollect.strings.inputs_type.photo'),
+            'entry_original',
+            $this->project->ref,
+            'non-existent-file.jpg'
+        );
+
+        $this->assertEquals(200, $response->status());
+        $cacheControl = $response->headers->get('Cache-Control');
+        $this->assertStringContainsString('no-store', $cacheControl);
+        $this->assertStringNotContainsString('max-age', $cacheControl);
+        $this->assertStringNotContainsString('immutable', $cacheControl);
     }
 
     public function test_it_returns_error_for_invalid_format()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Placeholder images (photos, thumbnails, and mobile logos) for missing media are no longer cached indefinitely — served with no-store so they can be refreshed when media is added or replaced.

* **Documentation**
  * Added guidance on placeholder image caching, the v query parameter and how edits bust photo cache.

* **Tests**
  * Added/updated tests to assert no-store cache behavior for placeholder media.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->