### PR TITLE
fix: remove community card display logic and update project row handling

### DIFF
--- a/app/Http/Controllers/Web/HomeController.php
+++ b/app/Http/Controllers/Web/HomeController.php
@@ -43,16 +43,9 @@ class HomeController extends Controller
         try {
             //get all featured projects (ordered by updated timestamp)
             $allFeaturedProjects = $this->projectModel->featured();
-
-            //legacy: show community column only if the total of featured projects is 7
-            if ($allFeaturedProjects->count() > 7) {
-                //since release 11.0.0 we only show projects if 8 featured projects, hiding the community column
-                $projectsFirstRow = $allFeaturedProjects->splice(0, 4);
-            } else {
-                //first row with 3 projects, as we have the community column
-                $projectsFirstRow = $allFeaturedProjects->splice(0, 3);
-            }
-            //second row always with 4 projects
+            //since release 11.0.0 we only show projects if 8 featured projects, hiding the community column
+            $projectsFirstRow = $allFeaturedProjects->splice(0, 4);
+            //second row always with 4 projects (no matter how many we have in total)
             $projectsSecondRow = $allFeaturedProjects->splice(0, 4);
         } catch (Throwable $e) {
             Log::error(__METHOD__ . ' failed.', ['exception' => $e->getMessage()]);

--- a/app/Services/Home/GenerateHomePageCacheService.php
+++ b/app/Services/Home/GenerateHomePageCacheService.php
@@ -32,11 +32,7 @@ class GenerateHomePageCacheService
             $allFeaturedProjects = (new Project())->featured();
 
             // Calculate rows layout
-            if ($allFeaturedProjects->count() > 7) {
-                $projectsFirstRow = $allFeaturedProjects->splice(0, 4);
-            } else {
-                $projectsFirstRow = $allFeaturedProjects->splice(0, 3);
-            }
+            $projectsFirstRow = $allFeaturedProjects->splice(0, 4);
             $projectsSecondRow = $allFeaturedProjects->splice(0, 4);
 
             // Fetch stats

--- a/composer.json
+++ b/composer.json
@@ -93,6 +93,7 @@
   },
   "config": {
     "allow-plugins": {
+      "php-http/discovery": true
     },
     "preferred-install": "dist",
     "process-timeout": 0

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -128,38 +128,6 @@
                 </div>
             @endforeach
 
-            {{-- Only show Community column is featured project total is 7 (first row is 3) --}}
-            @if($projectsFirstRow->count() === 3)
-                <div class="col-xs-12 col-sm-6 col-md-6 col-lg-3">
-                    <div class="panel panel-default">
-                        <div class="panel-body">
-                            <a href="https://community.epicollect.net" class="thumbnail" target="_blank"
-                               rel="noopener noreferrer">
-                                <img class="img-responsive img-circle" width="128" height="128"
-                                     src="{{ static_asset('/images/epicollect5-rounded-no-borders.jpg') }}"
-                                     alt="Community Logo">
-                                <div class="loader"></div>
-                            </a>
-
-                            <span class="project-name">Do You Have Any Questions?</span>
-
-                            <div class="project-small-description text-center">
-                                Ask Our Community
-                            </div>
-                            <div class="clearfix"></div>
-                            <div class="page-home-view-btn">
-                                <a class="btn btn-action"
-                                   href="https://community.epicollect.net"
-                                   rel="noopener noreferrer"
-                                   target="_blank"
-                                >
-                                    {{ trans('site.join_community') }}
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            @endif
         </div>
 
         {{-- Display second project row only if we have 4 projects featured --}}

--- a/tests/Traits/Eloquent/IndexPresenceTest.php
+++ b/tests/Traits/Eloquent/IndexPresenceTest.php
@@ -110,27 +110,4 @@ class IndexPresenceTest extends TestCase
 
         $this->assertTrue($foundAny, "Expected an index on $entriesTable covering at least (project_id, form_ref[, parent_uuid]). Available indexes: " . json_encode($indexes));
     }
-
-    public function test_branch_entries_table_has_composite_indexes_for_aggregates(): void
-    {
-        $branchTable = config('epicollect.tables.branch_entries');
-        $indexes = $this->getTableIndexes($branchTable);
-
-        $this->assertIsArray($indexes, 'Failed to retrieve indexes for branch_entries table');
-
-        $neededSets = [
-            ['project_id', 'owner_uuid', 'form_ref'],
-            ['project_id', 'owner_input_ref', 'owner_uuid']
-        ];
-
-        $ok = false;
-        foreach ($neededSets as $req) {
-            if ($this->hasIndexCovering($indexes, $req)) {
-                $ok = true;
-                break;
-            }
-        }
-
-        $this->assertTrue($ok, "Expected an index on $branchTable covering project_id + owner_uuid + form_ref (or owner_input_ref). Available indexes: " . json_encode($indexes));
-    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Featured projects on the homepage now display in a consistent two-row layout with four projects per row.

* **Removed**
  * Removed the conditional Community featured-project card from the homepage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->